### PR TITLE
Fix zerocoin primality test implementation

### DIFF
--- a/src/zerocoin/ParamGeneration.cpp
+++ b/src/zerocoin/ParamGeneration.cpp
@@ -645,10 +645,27 @@ generateIntegerFromSeed(uint32_t numBits, uint256 seed, uint32_t *numIterations)
 bool
 primalityTestByTrialDivision(uint32_t candidate)
 {
-	// TODO: HACK HACK WRONG WRONG
-	Bignum canBignum(candidate);
+        if(candidate < 2) {
+                return false;
+        }
 
-	return canBignum.isPrime();
+        // handle small primes quickly
+        if(candidate < 4) {
+                return true;
+        }
+
+        // even numbers other than two are not prime
+        if((candidate & 1) == 0) {
+                return false;
+        }
+
+        for(uint32_t i = 3; i <= candidate / i; i += 2) {
+                if(candidate % i == 0) {
+                        return false;
+                }
+        }
+
+        return true;
 }
 
 } // namespace libzerocoin

--- a/src/zerocoin/ParamGeneration.h
+++ b/src/zerocoin/ParamGeneration.h
@@ -46,7 +46,6 @@ Bignum              calculateGroupGenerator(uint256 seed, uint256 pSeed, uint256
 Bignum              generateRandomPrime(uint32_t primeBitLen, uint256 in_seed, uint256 *out_seed,
                                         uint32_t *prime_gen_counter);
 Bignum              generateIntegerFromSeed(uint32_t numBits, uint256 seed, uint32_t *numIterations);
-bool                primalityTestByTrialDivision(uint32_t candidate);
 
 }/* namespace libzerocoin */
 


### PR DESCRIPTION
## Summary
- implement proper 32-bit trial division in `primalityTestByTrialDivision`
- remove duplicated prototype from `ParamGeneration.h`

## Testing
- *No tests found or run*


------
https://chatgpt.com/codex/tasks/task_e_685486946ee08332887d978cebe26ace