### PR TITLE
Fix typo in version header comment

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -32,7 +32,7 @@ static const int DATABASE_VERSION = 70509;
 
 static const int PROTOCOL_VERSION = 60014;
 
-// intial proto version, to be increased after version/verack negotiation
+// initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
 // disconnect from peers older than this proto version


### PR DESCRIPTION
## Summary
- correct a spelling typo in `src/version.h` comment

## Testing
- `grep -n intial -r src | head`

------
https://chatgpt.com/codex/tasks/task_e_685488590a7c83328a127ffe00ed7f09