### PR TITLE
Add invalid Base64 decode tests

### DIFF
--- a/src/test/base64_tests.cpp
+++ b/src/test/base64_tests.cpp
@@ -17,6 +17,27 @@ BOOST_AUTO_TEST_CASE(base64_testvectors)
         std::string strDec = DecodeBase64(strEnc);
         BOOST_CHECK(strDec == vstrIn[i]);
     }
+
+    {
+        bool fInvalid = false;
+        std::vector<unsigned char> vchRet;
+
+        vchRet = DecodeBase64("!!", &fInvalid);
+        BOOST_CHECK(fInvalid || vchRet.empty());
+        BOOST_CHECK(DecodeBase64("!!").empty());
+
+        fInvalid = false;
+        vchRet = DecodeBase64("Zg", &fInvalid);
+        BOOST_CHECK(fInvalid);
+
+        fInvalid = false;
+        vchRet = DecodeBase64("Zg=", &fInvalid);
+        BOOST_CHECK(fInvalid);
+
+        fInvalid = false;
+        vchRet = DecodeBase64("Zg===", &fInvalid);
+        BOOST_CHECK(fInvalid);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- extend base64 test suite with invalid decode cases

## Testing
- `make -f makefile.unix` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68548904025c8332b61c6aa99781b0ef