### PR TITLE
Improve RPC accept handler error logging

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -723,9 +723,11 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol, 
 
     AcceptedConnectionImpl<ip::tcp>* tcp_conn = dynamic_cast< AcceptedConnectionImpl<ip::tcp>* >(conn);
 
-    // TODO: Actually handle errors
+    // Log and clean up immediately if there was an error accepting the connection
     if (error)
     {
+        error("RPCAcceptHandler: %s", error.message().c_str());
+        conn->close();
         delete conn;
     }
 


### PR DESCRIPTION
## Summary
- log RPC accept errors when an incoming connection fails
- close the socket before deleting the connection object

## Testing
- `make -f src/makefile.unix` *(fails: No rule to make target 'obj/alert.o')*

------
https://chatgpt.com/codex/tasks/task_e_68548ab3475083329a0714a99ace351b