### PR TITLE
Fix string returns in block browser functions

### DIFF
--- a/src/qt/blockbrowser.cpp
+++ b/src/qt/blockbrowser.cpp
@@ -56,7 +56,7 @@ std::string getBlockHash(int Height)
     int desiredheight;
     desiredheight = Height;
     if (desiredheight < 0 || desiredheight > nBestHeight)
-        return 0;
+        return std::string();
 
     CBlock block;
     CBlockIndex* pblockindex = mapBlockIndex[hashBestChain];
@@ -84,7 +84,7 @@ std::string getBlockMerkle(int Height)
     uint256 hash(strHash);
 
     if (mapBlockIndex.count(hash) == 0)
-        return 0;
+        return std::string();
 
     CBlock block;
     CBlockIndex* pblockindex = mapBlockIndex[hash];
@@ -123,7 +123,7 @@ std::string getBlockDebug(int Height)
     uint256 hash(strHash);
 
     if (mapBlockIndex.count(hash) == 0)
-        return 0;
+        return std::string();
 
     CBlock block;
     CBlockIndex* pblockindex = mapBlockIndex[hash];


### PR DESCRIPTION
## Summary
- return an empty string when a block isn't found instead of `0`
- touch up `getBlockHash`, `getBlockMerkle`, and `getBlockDebug`

## Testing
- `make -f makefile.unix -j2` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_685488eb4b9883328722770345582b46