### PR TITLE
Fix compile path and log RPC accept errors

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -5,7 +5,7 @@ MXE_INCLUDE_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/include
 MXE_LIB_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/lib
 SECP256K1_LIB_PATH=/usr/lib:/usr/local/bin
 
-cd /mnt/Mic2.0/src/leveldb
+cd "$(dirname "$0")/src/leveldb"
 TARGET_OS=NATIVE_WINDOWS make CC=/mnt/mxe/usr/bin/i686-w64-mingw32.static-gcc CXX=/mnt/mxe/usr/bin/i686-w64-mingw32.static-g++
 
 cd ../..

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -723,9 +723,9 @@ static void RPCAcceptHandler(boost::shared_ptr< basic_socket_acceptor<Protocol, 
 
     AcceptedConnectionImpl<ip::tcp>* tcp_conn = dynamic_cast< AcceptedConnectionImpl<ip::tcp>* >(conn);
 
-    // TODO: Actually handle errors
     if (error)
     {
+        printf("RPC accept error: %s\n", error.message().c_str());
         delete conn;
     }
 


### PR DESCRIPTION
## Summary
- make `compile.sh` use a repository-relative path instead of a hard-coded location
- log RPC accept errors in `src/bitcoinrpc.cpp`

## Testing
- `make -C src check` *(fails: No rule to make target `check`)*
- `make -C src -f makefile.unix` *(fails: missing Boost headers)*

------
https://chatgpt.com/codex/tasks/task_e_68548693fc6883329a1a4c56c158c4fc