### PR TITLE
Restore trial division prime check

### DIFF
--- a/src/zerocoin/ParamGeneration.cpp
+++ b/src/zerocoin/ParamGeneration.cpp
@@ -645,22 +645,16 @@ generateIntegerFromSeed(uint32_t numBits, uint256 seed, uint32_t *numIterations)
 bool
 primalityTestByTrialDivision(uint32_t candidate)
 {
-        if(candidate < 2) {
+        if (candidate < 2) {
                 return false;
         }
 
-        // handle small primes quickly
-        if(candidate < 4) {
-                return true;
+        if ((candidate % 2) == 0) {
+                return candidate == 2;
         }
 
-        // even numbers other than two are not prime
-        if((candidate & 1) == 0) {
-                return false;
-        }
-
-        for(uint32_t i = 3; i <= candidate / i; i += 2) {
-                if(candidate % i == 0) {
+        for (uint32_t i = 3; i * i <= candidate; i += 2) {
+                if ((candidate % i) == 0) {
                         return false;
                 }
         }

--- a/src/zerocoin/ParamGeneration.h
+++ b/src/zerocoin/ParamGeneration.h
@@ -31,7 +31,6 @@ void calculateGroupParamLengths(uint32_t maxPLen, uint32_t securityLevel,
 #define NUM_SCHNORRGEN_ATTEMPTS     10000
 
 // Prototypes
-bool                primalityTestByTrialDivision(uint32_t candidate);
 uint256             calculateSeed(Bignum modulus, std::string auxString, uint32_t securityLevel, std::string groupName);
 uint256             calculateGeneratorSeed(uint256 seed, uint256 pSeed, uint256 qSeed, std::string label, uint32_t index, uint32_t count);
 


### PR DESCRIPTION
## Summary
- implement real trial-division prime check
- clean up ParamGeneration header

## Testing
- `make -f makefile.unix test_Mousecoin` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_6854904b94ac8332ae9d0eb6e3987011