### PR TITLE
Add shell escaping for external commands

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -247,7 +247,6 @@ bool CAlert::ProcessAlert(bool fThread)
                 // Alert text should be plain ascii coming from a trusted source, but to
                 // be safe we first strip anything not in safeChars, then add single quotes around
                 // the whole string before passing it to the shell:
-                std::string singleQuote("'");
                 // safeChars chosen to allow simple messages/URLs/email addresses, but avoid anything
                 // even possibly remotely dangerous like & or >
                 std::string safeChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890 .,;_/:?@");
@@ -257,7 +256,7 @@ bool CAlert::ProcessAlert(bool fThread)
                     if (safeChars.find(strStatusBar[i]) != std::string::npos)
                         safeStatus.push_back(strStatusBar[i]);
                 }
-                safeStatus = singleQuote+safeStatus+singleQuote;
+                safeStatus = ShellEscape(safeStatus);
                 boost::replace_all(strCmd, "%s", safeStatus);
 
                 if (fThread)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1924,7 +1924,8 @@ bool CBlock::SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew)
 
     if (!fIsInitialDownload && !strCmd.empty())
     {
-        boost::replace_all(strCmd, "%s", hashBestChain.GetHex());
+        std::string safeHash = ShellEscape(hashBestChain.GetHex());
+        boost::replace_all(strCmd, "%s", safeHash);
         boost::thread t(runCommand, strCmd); // thread runs free
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1288,6 +1288,33 @@ boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate)
 }
 #endif
 
+std::string ShellEscape(const std::string& arg)
+{
+#ifdef WIN32
+    std::string escaped = "\"";
+    for (std::string::const_iterator it = arg.begin(); it != arg.end(); ++it)
+    {
+        if (*it == '"')
+            escaped += "\\\"";
+        else
+            escaped += *it;
+    }
+    escaped += "\"";
+    return escaped;
+#else
+    std::string escaped = "'";
+    for (std::string::const_iterator it = arg.begin(); it != arg.end(); ++it)
+    {
+        if (*it == '\'')
+            escaped += "'\\''";
+        else
+            escaped += *it;
+    }
+    escaped += "'";
+    return escaped;
+#endif
+}
+
 void runCommand(std::string strCommand)
 {
     int nErr = ::system(strCommand.c_str());

--- a/src/util.h
+++ b/src/util.h
@@ -236,6 +236,7 @@ int64_t GetTimeOffset();
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 void AddTimeData(const CNetAddr& ip, int64_t nTime);
+std::string ShellEscape(const std::string& arg);
 void runCommand(std::string strCommand);
 long hex2long(const char* hexString);
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -540,9 +540,10 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn)
         // notify an external script when a wallet transaction comes in or is updated
         std::string strCmd = GetArg("-walletnotify", "");
 
-        if ( !strCmd.empty())
+        if (!strCmd.empty())
         {
-            boost::replace_all(strCmd, "%s", wtxIn.GetHash().GetHex());
+            std::string safeHash = ShellEscape(wtxIn.GetHash().GetHex());
+            boost::replace_all(strCmd, "%s", safeHash);
             boost::thread t(runCommand, strCmd); // thread runs free
         }
 


### PR DESCRIPTION
## Summary
- escape arguments to `system()` with new `ShellEscape` helper
- sanitize strings before running alert/wallet/block notify hooks

## Testing
- `make -f src/makefile.unix` *(fails: No rule to make target `obj/alert.o`)*

------
https://chatgpt.com/codex/tasks/task_e_6854935c5e248332bbce23be0009f48e