### PR TITLE
Parameterize build script paths

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,26 +1,43 @@
 #!/bin/bash
-export PATH=/mnt/mxe/usr/bin:$PATH
-MXE_PATH=$HOME/MXE
-MXE_INCLUDE_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/include
-MXE_LIB_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/lib
-SECP256K1_LIB_PATH=/usr/lib:/usr/local/bin
 
-cd /mnt/Mic2.0/src/leveldb
-TARGET_OS=NATIVE_WINDOWS make CC=/mnt/mxe/usr/bin/i686-w64-mingw32.static-gcc CXX=/mnt/mxe/usr/bin/i686-w64-mingw32.static-g++
+# Environment variables that can be overridden by the user:
+#   MXE_PREFIX     - path to the MXE installation prefix
+#                    (default: /mnt/mxe)
+#   MXE_TARGET     - MXE target triplet
+#                    (default: i686-w64-mingw32.static)
+#   PROJECT_ROOT   - path to the Mousecoin source tree
+#                    (default: directory containing this script)
+#   JOBS           - number of parallel jobs for make (default: 16)
+#   SECP256K1_LIB_PATH - additional library path for secp256k1
+#                    (default: /usr/lib:/usr/local/bin)
+
+MXE_PREFIX=${MXE_PREFIX:-/mnt/mxe}
+MXE_TARGET=${MXE_TARGET:-i686-w64-mingw32.static}
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PROJECT_ROOT=${PROJECT_ROOT:-$SCRIPT_DIR}
+JOBS=${JOBS:-16}
+SECP256K1_LIB_PATH=${SECP256K1_LIB_PATH:-/usr/lib:/usr/local/bin}
+
+export PATH="$MXE_PREFIX/usr/bin:$PATH"
+
+cd "$PROJECT_ROOT/src/leveldb"
+TARGET_OS=NATIVE_WINDOWS make \
+    CC="$MXE_PREFIX/usr/bin/${MXE_TARGET}-gcc" \
+    CXX="$MXE_PREFIX/usr/bin/${MXE_TARGET}-g++"
 
 cd ../..
 
-/mnt/mxe/usr/bin/i686-w64-mingw32.static-qmake-qt5 \
-	BOOST_LIB_SUFFIX=-mt \
-	BOOST_THREAD_LIB_SUFFIX=_win32-mt \
-	BOOST_INCLUDE_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/include/boost \
-	BOOST_LIB_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/lib \
-	OPENSSL_INCLUDE_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/include/openssl \
-	OPENSSL_LIB_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/lib \
-	BDB_INCLUDE_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/include \
-	BDB_LIB_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/lib \
-	MINIUPNPC_INCLUDE_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/include \
-	MINIUPNPC_LIB_PATH=/mnt/mxe/usr/i686-w64-mingw32.static/lib \
-	QMAKE_LRELEASE=/mnt/mxe/usr/i686-w64-mingw32.static/qt5/bin/lrelease Mic3.pro
+"$MXE_PREFIX/usr/bin/${MXE_TARGET}-qmake-qt5" \
+        BOOST_LIB_SUFFIX=-mt \
+        BOOST_THREAD_LIB_SUFFIX=_win32-mt \
+        BOOST_INCLUDE_PATH="$MXE_PREFIX/usr/$MXE_TARGET/include/boost" \
+        BOOST_LIB_PATH="$MXE_PREFIX/usr/$MXE_TARGET/lib" \
+        OPENSSL_INCLUDE_PATH="$MXE_PREFIX/usr/$MXE_TARGET/include/openssl" \
+        OPENSSL_LIB_PATH="$MXE_PREFIX/usr/$MXE_TARGET/lib" \
+        BDB_INCLUDE_PATH="$MXE_PREFIX/usr/$MXE_TARGET/include" \
+        BDB_LIB_PATH="$MXE_PREFIX/usr/$MXE_TARGET/lib" \
+        MINIUPNPC_INCLUDE_PATH="$MXE_PREFIX/usr/$MXE_TARGET/include" \
+        MINIUPNPC_LIB_PATH="$MXE_PREFIX/usr/$MXE_TARGET/lib" \
+        QMAKE_LRELEASE="$MXE_PREFIX/usr/$MXE_TARGET/qt5/bin/lrelease" Mic3.pro
 
-make -j 16 -f Makefile.Release
+make -j "$JOBS" -f Makefile.Release


### PR DESCRIPTION
## Summary
- add environment variable documentation to `compile.sh`
- allow overriding MXE paths via `MXE_PREFIX`, `MXE_TARGET`, and other vars
- use these variables throughout the build steps

## Testing
- `bash -n compile.sh`
- `MXE_PREFIX=/opt/mxe MXE_TARGET=x86_64-w64-mingw32.static JOBS=4 bash -x compile.sh` *(fails: `/opt/mxe/usr/bin/x86_64-w64-mingw32.static-qmake-qt5: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68549355f0008332bafc52c8a7e62bec