### PR TITLE
Port utility scripts to Python3

### DIFF
--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Copyright (C) 2011  Patrick "p2k" Schneider <me@p2k-network.org>
@@ -195,9 +195,11 @@ class DeploymentInfo(object):
 
 def getFrameworks(binaryPath, verbose):
     if verbose >= 3:
-        print "Inspecting with otool: " + binaryPath
+        print("Inspecting with otool: " + binaryPath)
     otool = subprocess.Popen(["otool", "-L", binaryPath], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     o_stdout, o_stderr = otool.communicate()
+    o_stdout = o_stdout.decode()
+    o_stderr = o_stderr.decode()
     if otool.returncode != 0:
         if verbose >= 1:
             sys.stderr.write(o_stderr)
@@ -214,8 +216,8 @@ def getFrameworks(binaryPath, verbose):
         info = FrameworkInfo.fromOtoolLibraryLine(line.strip())
         if info is not None:
             if verbose >= 3:
-                print "Found framework:"
-                print info
+                print("Found framework:")
+                print(info)
             libraries.append(info)
     
     return libraries
@@ -225,23 +227,23 @@ def runInstallNameTool(action, *args):
 
 def changeInstallName(oldName, newName, binaryPath, verbose):
     if verbose >= 3:
-        print "Using install_name_tool:"
-        print " in", binaryPath
-        print " change reference", oldName
-        print " to", newName
+        print("Using install_name_tool:")
+        print(" in", binaryPath)
+        print(" change reference", oldName)
+        print(" to", newName)
     runInstallNameTool("change", oldName, newName, binaryPath)
 
 def changeIdentification(id, binaryPath, verbose):
     if verbose >= 3:
-        print "Using install_name_tool:"
-        print " change identification in", binaryPath
-        print " to", id
+        print("Using install_name_tool:")
+        print(" change identification in", binaryPath)
+        print(" to", id)
     runInstallNameTool("id", id, binaryPath)
 
 def runStrip(binaryPath, verbose):
     if verbose >= 3:
-        print "Using strip:"
-        print " stripped", binaryPath
+        print("Using strip:")
+        print(" stripped", binaryPath)
     subprocess.check_call(["strip", "-x", binaryPath])
 
 def copyFramework(framework, path, verbose):
@@ -265,8 +267,8 @@ def copyFramework(framework, path, verbose):
     
     shutil.copy2(fromPath, toPath)
     if verbose >= 3:
-        print "Copied:", fromPath
-        print " to:", toPath
+        print("Copied:", fromPath)
+        print(" to:", toPath)
 
     permissions = os.stat(toPath)
     if not permissions.st_mode & stat.S_IWRITE:
@@ -278,16 +280,16 @@ def copyFramework(framework, path, verbose):
             toResourcesDir = os.path.join(path, framework.destinationResourcesDirectory)
             shutil.copytree(fromResourcesDir, toResourcesDir)
             if verbose >= 3:
-                print "Copied resources:", fromResourcesDir
-                print " to:", toResourcesDir
+                print("Copied resources:", fromResourcesDir)
+                print(" to:", toResourcesDir)
     elif framework.frameworkName.startswith("libQtGui"): # Copy qt_menu.nib (applies to non-framework layout)
         qtMenuNibSourcePath = os.path.join(framework.frameworkDirectory, "Resources", "qt_menu.nib")
         qtMenuNibDestinationPath = os.path.join(path, "Contents", "Resources", "qt_menu.nib")
         if os.path.exists(qtMenuNibSourcePath) and not os.path.exists(qtMenuNibDestinationPath):
             shutil.copytree(qtMenuNibSourcePath, qtMenuNibDestinationPath)
             if verbose >= 3:
-                print "Copied for libQtGui:", qtMenuNibSourcePath
-                print " to:", qtMenuNibDestinationPath
+                print("Copied for libQtGui:", qtMenuNibSourcePath)
+                print(" to:", qtMenuNibDestinationPath)
     
     return toPath
 
@@ -300,7 +302,7 @@ def deployFrameworks(frameworks, bundlePath, binaryPath, strip, verbose, deploym
         deploymentInfo.deployedFrameworks.append(framework.frameworkName)
         
         if verbose >= 2:
-            print "Processing", framework.frameworkName, "..."
+            print("Processing", framework.frameworkName, "...")
         
         # Get the Qt path from one of the Qt frameworks
         if deploymentInfo.qtPath is None and framework.isQtFramework():
@@ -308,7 +310,7 @@ def deployFrameworks(frameworks, bundlePath, binaryPath, strip, verbose, deploym
         
         if framework.installName.startswith("@executable_path"):
             if verbose >= 2:
-                print framework.frameworkName, "already deployed, skipping."
+                print(framework.frameworkName, "already deployed, skipping.")
             continue
         
         # install_name_tool the new id into the binary
@@ -340,7 +342,7 @@ def deployFrameworks(frameworks, bundlePath, binaryPath, strip, verbose, deploym
 def deployFrameworksForAppBundle(applicationBundle, strip, verbose):
     frameworks = getFrameworks(applicationBundle.binaryPath, verbose)
     if len(frameworks) == 0 and verbose >= 1:
-        print "Warning: Could not find any external frameworks to deploy in %s." % (applicationBundle.path)
+        print("Warning: Could not find any external frameworks to deploy in %s." % (applicationBundle.path))
         return DeploymentInfo()
     else:
         return deployFrameworks(frameworks, applicationBundle.path, applicationBundle.binaryPath, strip, verbose)
@@ -396,7 +398,7 @@ def deployPlugins(appBundleInfo, deploymentInfo, strip, verbose):
     
     for pluginDirectory, pluginName in plugins:
         if verbose >= 2:
-            print "Processing plugin", os.path.join(pluginDirectory, pluginName), "..."
+            print("Processing plugin", os.path.join(pluginDirectory, pluginName), "...")
         
         sourcePath = os.path.join(deploymentInfo.pluginPath, pluginDirectory, pluginName)
         destinationDirectory = os.path.join(appBundleInfo.pluginPath, pluginDirectory)
@@ -406,8 +408,8 @@ def deployPlugins(appBundleInfo, deploymentInfo, strip, verbose):
         destinationPath = os.path.join(destinationDirectory, pluginName)
         shutil.copy2(sourcePath, destinationPath)
         if verbose >= 3:
-            print "Copied:", sourcePath
-            print " to:", destinationPath
+            print("Copied:", sourcePath)
+            print(" to:", destinationPath)
         
         if strip:
             runStrip(destinationPath, verbose)
@@ -461,7 +463,7 @@ app_bundle_name = os.path.splitext(os.path.basename(app_bundle))[0]
 
 for p in config.add_resources:
     if verbose >= 3:
-        print "Checking for \"%s\"..." % p
+        print("Checking for \"%s\"..." % p)
     if not os.path.exists(p):
         if verbose >= 1:
             sys.stderr.write("Error: Could not find additional resource file \"%s\"\n" % (p))
@@ -471,7 +473,7 @@ for p in config.add_resources:
 
 if len(config.fancy) == 1:
     if verbose >= 3:
-        print "Fancy: Importing plistlib..."
+        print("Fancy: Importing plistlib...")
     try:
         import plistlib
     except ImportError:
@@ -480,7 +482,7 @@ if len(config.fancy) == 1:
         sys.exit(1)
     
     if verbose >= 3:
-        print "Fancy: Importing appscript..."
+        print("Fancy: Importing appscript...")
     try:
         import appscript
     except ImportError:
@@ -491,37 +493,38 @@ if len(config.fancy) == 1:
     
     p = config.fancy[0]
     if verbose >= 3:
-        print "Fancy: Loading \"%s\"..." % p
+        print("Fancy: Loading \"%s\"..." % p)
     if not os.path.exists(p):
         if verbose >= 1:
             sys.stderr.write("Error: Could not find fancy disk image plist at \"%s\"\n" % (p))
         sys.exit(1)
     
     try:
-        fancy = plistlib.readPlist(p)
-    except:
+        with open(p, 'rb') as fp:
+            fancy = plistlib.load(fp)
+    except Exception:
         if verbose >= 1:
             sys.stderr.write("Error: Could not parse fancy disk image plist at \"%s\"\n" % (p))
         sys.exit(1)
     
     try:
-        assert not fancy.has_key("window_bounds") or (isinstance(fancy["window_bounds"], list) and len(fancy["window_bounds"]) == 4)
-        assert not fancy.has_key("background_picture") or isinstance(fancy["background_picture"], str)
-        assert not fancy.has_key("icon_size") or isinstance(fancy["icon_size"], int)
-        assert not fancy.has_key("applications_symlink") or isinstance(fancy["applications_symlink"], bool)
-        if fancy.has_key("items_position"):
+        assert ("window_bounds" not in fancy) or (isinstance(fancy["window_bounds"], list) and len(fancy["window_bounds"]) == 4)
+        assert ("background_picture" not in fancy) or isinstance(fancy["background_picture"], str)
+        assert ("icon_size" not in fancy) or isinstance(fancy["icon_size"], int)
+        assert ("applications_symlink" not in fancy) or isinstance(fancy["applications_symlink"], bool)
+        if "items_position" in fancy:
             assert isinstance(fancy["items_position"], dict)
-            for key, value in fancy["items_position"].iteritems():
+            for key, value in fancy["items_position"].items():
                 assert isinstance(value, list) and len(value) == 2 and isinstance(value[0], int) and isinstance(value[1], int)
     except:
         if verbose >= 1:
             sys.stderr.write("Error: Bad format of fancy disk image plist at \"%s\"\n" % (p))
         sys.exit(1)
     
-    if fancy.has_key("background_picture"):
+    if "background_picture" in fancy:
         bp = fancy["background_picture"]
         if verbose >= 3:
-            print "Fancy: Resolving background picture \"%s\"..." % bp
+            print("Fancy: Resolving background picture \"%s\"..." % bp)
         if not os.path.exists(bp):
             bp = os.path.join(os.path.dirname(p), bp)
             if not os.path.exists(bp):
@@ -537,7 +540,7 @@ else:
 
 if os.path.exists("dist"):
     if verbose >= 2:
-        print "+ Removing old dist folder +"
+        print("+ Removing old dist folder +")
     
     shutil.rmtree("dist")
 
@@ -546,9 +549,9 @@ if os.path.exists("dist"):
 target = os.path.join("dist", app_bundle)
 
 if verbose >= 2:
-    print "+ Copying source bundle +"
+    print("+ Copying source bundle +")
 if verbose >= 3:
-    print app_bundle, "->", target
+    print(app_bundle, "->", target)
 
 os.mkdir("dist")
 shutil.copytree(app_bundle, target)
@@ -558,7 +561,7 @@ applicationBundle = ApplicationBundleInfo(target)
 # ------------------------------------------------
 
 if verbose >= 2:
-    print "+ Deploying frameworks +"
+    print("+ Deploying frameworks +")
 
 try:
     deploymentInfo = deployFrameworksForAppBundle(applicationBundle, config.strip, verbose)
@@ -577,7 +580,7 @@ except RuntimeError as e:
 
 if config.plugins:
     if verbose >= 2:
-        print "+ Deploying plugins +"
+        print("+ Deploying plugins +")
     
     try:
         deployPlugins(applicationBundle, deploymentInfo, config.strip, verbose)
@@ -596,7 +599,7 @@ else:
     for lng_file in add_qt_tr:
         p = os.path.join(qt_tr_dir, lng_file)
         if verbose >= 3:
-            print "Checking for \"%s\"..." % p
+            print("Checking for \"%s\"..." % p)
         if not os.path.exists(p):
             if verbose >= 1:
                 sys.stderr.write("Error: Could not find Qt translation file \"%s\"\n" % (lng_file))
@@ -605,7 +608,7 @@ else:
 # ------------------------------------------------
 
 if verbose >= 2:
-    print "+ Installing qt.conf +"
+    print("+ Installing qt.conf +")
 
 f = open(os.path.join(applicationBundle.resourcesPath, "qt.conf"), "wb")
 f.write(qt_conf)
@@ -614,22 +617,22 @@ f.close()
 # ------------------------------------------------
 
 if len(add_qt_tr) > 0 and verbose >= 2:
-    print "+ Adding Qt translations +"
+    print("+ Adding Qt translations +")
 
 for lng_file in add_qt_tr:
     if verbose >= 3:
-        print os.path.join(qt_tr_dir, lng_file), "->", os.path.join(applicationBundle.resourcesPath, lng_file)
+        print(os.path.join(qt_tr_dir, lng_file), "->", os.path.join(applicationBundle.resourcesPath, lng_file))
     shutil.copy2(os.path.join(qt_tr_dir, lng_file), os.path.join(applicationBundle.resourcesPath, lng_file))
 
 # ------------------------------------------------
 
 if len(config.add_resources) > 0 and verbose >= 2:
-    print "+ Adding additional resources +"
+    print("+ Adding additional resources +")
 
 for p in config.add_resources:
     t = os.path.join(applicationBundle.resourcesPath, os.path.basename(p))
     if verbose >= 3:
-        print p, "->", t
+        print(p, "->", t)
     if os.path.isdir(p):
         shutil.copytree(p, t)
     else:
@@ -640,7 +643,7 @@ for p in config.add_resources:
 if config.dmg is not None:
     def runHDIUtil(verb, image_basename, **kwargs):
         hdiutil_args = ["hdiutil", verb, image_basename + ".dmg"]
-        if kwargs.has_key("capture_stdout"):
+        if "capture_stdout" in kwargs:
             del kwargs["capture_stdout"]
             run = subprocess.check_output
         else:
@@ -650,7 +653,7 @@ if config.dmg is not None:
                 hdiutil_args.append("-verbose")
             run = subprocess.check_call
         
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             hdiutil_args.append("-" + key)
             if not value is True:
                 hdiutil_args.append(str(value))
@@ -659,9 +662,9 @@ if config.dmg is not None:
     
     if verbose >= 2:
         if fancy is None:
-            print "+ Creating .dmg disk image +"
+            print("+ Creating .dmg disk image +")
         else:
-            print "+ Preparing .dmg disk image +"
+            print("+ Preparing .dmg disk image +")
     
     if config.dmg != "":
         dmg_name = config.dmg
@@ -676,7 +679,7 @@ if config.dmg is not None:
             sys.exit(e.returncode)
     else:
         if verbose >= 3:
-            print "Determining size of \"dist\"..."
+            print("Determining size of \"dist\"...")
         size = 0
         for path, dirs, files in os.walk("dist"):
             for file in files:
@@ -684,16 +687,18 @@ if config.dmg is not None:
         size += int(size * 0.1)
         
         if verbose >= 3:
-            print "Creating temp image for modification..."
+            print("Creating temp image for modification...")
         try:
             runHDIUtil("create", dmg_name + ".temp", srcfolder="dist", format="UDRW", size=size, volname=app_bundle_name, ov=True)
         except subprocess.CalledProcessError as e:
             sys.exit(e.returncode)
         
         if verbose >= 3:
-            print "Attaching temp image..."
+            print("Attaching temp image...")
         try:
             output = runHDIUtil("attach", dmg_name + ".temp", readwrite=True, noverify=True, noautoopen=True, capture_stdout=True)
+            if isinstance(output, bytes):
+                output = output.decode()
         except subprocess.CalledProcessError as e:
             sys.exit(e.returncode)
         
@@ -702,12 +707,12 @@ if config.dmg is not None:
         disk_name = m.group(1)
         
         if verbose >= 2:
-            print "+ Applying fancy settings +"
+            print("+ Applying fancy settings +")
         
-        if fancy.has_key("background_picture"):
+        if "background_picture" in fancy:
             bg_path = os.path.join(disk_root, os.path.basename(fancy["background_picture"]))
             if verbose >= 3:
-                print fancy["background_picture"], "->", bg_path
+                print(fancy["background_picture"], "->", bg_path)
             shutil.copy2(fancy["background_picture"], bg_path)
         else:
             bg_path = None
@@ -722,16 +727,16 @@ if config.dmg is not None:
         window.current_view.set(appscript.k.icon_view)
         window.toolbar_visible.set(False)
         window.statusbar_visible.set(False)
-        if fancy.has_key("window_bounds"):
+        if "window_bounds" in fancy:
             window.bounds.set(fancy["window_bounds"])
         view_options = window.icon_view_options
         view_options.arrangement.set(appscript.k.not_arranged)
-        if fancy.has_key("icon_size"):
+        if "icon_size" in fancy:
             view_options.icon_size.set(fancy["icon_size"])
         if bg_path is not None:
             view_options.background_picture.set(disk.files[os.path.basename(bg_path)])
-        if fancy.has_key("items_position"):
-            for name, position in fancy["items_position"].iteritems():
+        if "items_position" in fancy:
+            for name, position in fancy["items_position"].items():
                 window.items[name].position.set(position)
         disk.close()
         if bg_path is not None:
@@ -741,7 +746,7 @@ if config.dmg is not None:
         disk.eject()
         
         if verbose >= 2:
-            print "+ Finalizing .dmg disk image +"
+            print("+ Finalizing .dmg disk image +")
         
         try:
             runHDIUtil("convert", dmg_name + ".temp", format="UDBZ", o=dmg_name + ".dmg", ov=True)
@@ -753,6 +758,6 @@ if config.dmg is not None:
 # ------------------------------------------------
 
 if verbose >= 2:
-    print "+ Done +"
+    print("+ Done +")
 
 sys.exit(0)

--- a/contrib/qt_translations.py
+++ b/contrib/qt_translations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Helpful little script that spits out a comma-separated list of
 # language codes for Qt icons that should be included
@@ -18,5 +18,5 @@ d2 = sys.argv[2]
 l1 = set([ re.search(r'qt_(.*).qm', f).group(1) for f in glob.glob(os.path.join(d1, 'qt_*.qm')) ])
 l2 = set([ re.search(r'bitcoin_(.*).qm', f).group(1) for f in glob.glob(os.path.join(d2, 'bitcoin_*.qm')) ])
 
-print ",".join(sorted(l1.intersection(l2)))
+print(",".join(sorted(l1.intersection(l2))))
 

--- a/share/qt/extract_strings_qt.py
+++ b/share/qt/extract_strings_qt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 '''
 Extract _("...") strings for translation and convert to Qt4 stringdefs so that
 they can be picked up by Qt linguist.
@@ -48,10 +48,10 @@ def parse_po(text):
 files = glob.glob('src/*.cpp') + glob.glob('src/*.h') 
 
 # xgettext -n --keyword=_ $FILES
-child = Popen(['xgettext','--output=-','-n','--keyword=_'] + files, stdout=PIPE)
+child = Popen(['xgettext', '--output=-', '-n', '--keyword=_'] + files, stdout=PIPE)
 (out, err) = child.communicate()
 
-messages = parse_po(out) 
+messages = parse_po(out.decode('utf-8'))
 
 f = open(OUT_CPP, 'w')
 f.write("""#include <QtGlobal>

--- a/share/qt/make_spinner.py
+++ b/share/qt/make_spinner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # W.J. van der Laan, 2011
 # Make spinning .mng animation from a .png
 # Requires imagemagick 6.7+
@@ -26,7 +26,7 @@ def frame_to_filename(frame):
     return path.join(TMPDIR, TMPNAME % frame)
 
 frame_files = []
-for frame in xrange(NUMFRAMES):
+for frame in range(NUMFRAMES):
     rotation = (frame + 0.5) / NUMFRAMES * 360.0
     if CLOCKWISE:
         rotation = -rotation


### PR DESCRIPTION
## Summary
- use `env python3` in script shebangs
- modernize Python syntax for compatibility with Python 3
- decode subprocess output for proper string handling

## Testing
- `python3 -m py_compile share/qt/make_spinner.py share/qt/extract_strings_qt.py contrib/qt_translations.py contrib/macdeploy/macdeployqtplus`

------
https://chatgpt.com/codex/tasks/task_e_68549344e3ec8332ab83994ca76f8919