### PR TITLE
Update Qt project references

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -20,7 +20,7 @@ override_dh_auto_clean:
 	cd src; $(MAKE) -f makefile.unix clean
 
 override_dh_auto_configure:
-	qmake Mousecoin-qt.pro USE_QRCODE=1
+       qmake Mic3.pro USE_QRCODE=1
 
 override_dh_auto_test:
 	cd src; $(MAKE) -f makefile.unix test_Mousecoin

--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -24,7 +24,7 @@ then execute the following:
     qmake
     make
 
-Alternatively, install Qt Creator and open the `Mousecoin-qt.pro` file.
+Alternatively, install Qt Creator and open the `Mic3.pro` file.
 
 An executable named `Mousecoin-qt` will be built.
 


### PR DESCRIPTION
## Summary
- reference `Mic3.pro` in Qt README
- update Debian packaging rules to use `Mic3.pro`

## Testing
- `dpkg-buildpackage -us -uc -b` *(fails: source package name 'Mousecoin' is illegal)*

------
https://chatgpt.com/codex/tasks/task_e_68549774762c8332824c6a817403fe63