### PR TITLE
Fix makefile architecture detection

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -5,7 +5,7 @@
 USE_UPNP:=0
 
 LINK:=$(CXX)
-ARCH:=$(system lscpu | head -n 1 | awk '{print $2}')
+ARCH := $(shell lscpu | head -n 1 | awk '{print $2}')
 
 DEFS=-DBOOST_SPIRIT_THREADSAFE
 


### PR DESCRIPTION
## Summary
- fix ARCH detection in `makefile.unix`

## Testing
- `make -f makefile.unix` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854976f118483329df4eaa5e6a403ff