### PR TITLE
Fix architecture detection on Unix build

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -5,7 +5,7 @@
 USE_UPNP:=0
 
 LINK:=$(CXX)
-ARCH := $(shell lscpu | head -n 1 | awk '{print $2}')
+ARCH := $(shell uname -m)
 
 DEFS=-DBOOST_SPIRIT_THREADSAFE
 


### PR DESCRIPTION
## Summary
- read build architecture from `uname -m` instead of `lscpu`
- keep the i686 check for 32‑bit builds

## Testing
- `make -f makefile.unix` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68549aa2648083329d0e090fe71d63d5