### PR TITLE
Fix architecture detection in Raspberry Pi makefile

### DIFF
--- a/src/makefile.rpi
+++ b/src/makefile.rpi
@@ -22,7 +22,7 @@ USE_IPV6 := 1
 USE_UPNP := 0
 
 LINK:=$(CXX)
-ARCH:=$(system lscpu | head -n 1 | awk '{print $2}')
+ARCH := $(shell lscpu | head -n 1 | awk '{print $$2}')
 
 DEFS=-DBOOST_SPIRIT_THREADSAFE
 


### PR DESCRIPTION
## Summary
- use `$(shell ...)` in `src/makefile.rpi` to detect the architecture

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68549a92e06483328640a59bf89d90c8