### PR TITLE
Update Boost version references

### DIFF
--- a/Mic3.pro
+++ b/Mic3.pro
@@ -366,7 +366,7 @@ OTHER_FILES += \
 # platform specific defaults, if not overridden on command line
 isEmpty(BOOST_LIB_SUFFIX) {
     macx:BOOST_LIB_SUFFIX = -mt
-    windows:BOOST_LIB_SUFFIX = -mgw49-mt-s-1_57
+    windows:BOOST_LIB_SUFFIX = -mgw49-mt-s-1_83
 }
 
 isEmpty(BOOST_THREAD_LIB_SUFFIX) {

--- a/contrib/gitian-descriptors/boost-win32.yml
+++ b/contrib/gitian-descriptors/boost-win32.yml
@@ -11,12 +11,12 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "boost_1_47_0.tar.bz2"
+- "boost_1_83_0.tar.bz2"
 script: |
   TMPDIR="$HOME/tmpdir"
   mkdir -p $TMPDIR/bin/$GBUILD_BITS $TMPDIR/include
-  tar xjf boost_1_47_0.tar.bz2
-  cd boost_1_47_0
+  tar xjf boost_1_83_0.tar.bz2
+  cd boost_1_83_0
   echo "using gcc : 4.4 : i586-mingw32msvc-g++
         :
         <rc>i586-mingw32msvc-windres
@@ -34,5 +34,5 @@ script: |
   cd $TMPDIR
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
-  zip -r boost-win32-1.47.0-gitian.zip *
-  cp boost-win32-1.47.0-gitian.zip $OUTDIR
+  zip -r boost-win32-1.83.0-gitian.zip *
+  cp boost-win32-1.83.0-gitian.zip $OUTDIR

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -16,7 +16,7 @@ remotes:
   "dir": "ppcoin"
 files:
 - "qt-win32-4.7.4-gitian.zip"
-- "boost-win32-1.47.0-gitian.zip"
+- "boost-win32-1.83.0-gitian.zip"
 - "ppcoin-deps-0.0.1.zip"
 script: |
   #
@@ -26,10 +26,10 @@ script: |
   cd $HOME/build/
   export PATH=$PATH:$HOME/qt/bin/
   #
-  mkdir boost_1_47_0
-  cd boost_1_47_0
+  mkdir boost_1_83_0
+  cd boost_1_83_0
   mkdir -p stage/lib
-  unzip ../boost-win32-1.47.0-gitian.zip
+  unzip ../boost-win32-1.83.0-gitian.zip
   cd bin/$GBUILD_BITS
   for lib in *; do
     i586-mingw32msvc-ar rc ../../stage/lib/libboost_${lib}-mt-s.a $lib/*.o
@@ -51,7 +51,7 @@ script: |
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
-  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-4.8.30.NC/build_unix BDB_INCLUDE_PATH=$HOME/build/db-4.8.30.NC/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_47_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_47_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-1.0.1b OPENSSL_INCLUDE_PATH=$HOME/build/openssl-1.0.1b/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.2.0/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.2.0 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=ppcoin QMAKE_LFLAGS=-frandom-seed=ppcoin USE_BUILD_INFO=1
+  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-4.8.30.NC/build_unix BDB_INCLUDE_PATH=$HOME/build/db-4.8.30.NC/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_83_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_83_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-1.0.1b OPENSSL_INCLUDE_PATH=$HOME/build/openssl-1.0.1b/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.2.0/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.2.0 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=ppcoin QMAKE_LFLAGS=-frandom-seed=ppcoin USE_BUILD_INFO=1
   make $MAKEOPTS
   cp release/ppcoin-qt.exe $OUTDIR/
   #

--- a/doc/build-msw.txt
+++ b/doc/build-msw.txt
@@ -26,7 +26,7 @@ Libraries you need to download separately and build:
                 default path               download
 OpenSSL         \openssl-1.0.1b-mgw        https://www.openssl.org/source/
 Berkeley DB     \db-4.8.30.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
-Boost           \boost-1.47.0-mgw          http://www.boost.org/users/download/
+Boost           \boost-1.83.0-mgw          http://www.boost.org/users/download/
 miniupnpc       \miniupnpc-1.6-mgw         https://miniupnp.tuxfamily.org/files/
 
 Their licenses:
@@ -38,7 +38,7 @@ miniupnpc      New (3-clause) BSD license
 Versions used in this release:
 OpenSSL      1.0.1b
 Berkeley DB  4.8.30.NC
-Boost        1.47.0
+Boost        1.83.0
 miniupnpc    1.6
 
 
@@ -63,7 +63,7 @@ Boost
 -----
 DOS prompt:
 downloaded boost jam 3.1.18
-cd \boost-1.47.0-mgw
+cd \boost-1.83.0-mgw
 bjam toolset=gcc --build-type=complete stage
 
 MiniUPnPc

--- a/doc/release-process.txt
+++ b/doc/release-process.txt
@@ -29,11 +29,11 @@
    wget 'http://zlib.net/zlib-1.2.6.tar.gz'
    wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.9.tar.gz'
    wget 'http://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'
-   wget 'http://downloads.sourceforge.net/project/boost/boost/1.47.0/boost_1_47_0.tar.bz2'
+  wget 'http://downloads.sourceforge.net/project/boost/boost/1.83.0/boost_1_83_0.tar.bz2'
    wget 'http://download.qt.nokia.com/qt/source/qt-everywhere-opensource-src-4.7.4.tar.gz'
    cd ..
-   ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-win32.yml
-   cp build/out/boost-win32-1.47.0-gitian.zip inputs/
+  ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-win32.yml
+  cp build/out/boost-win32-1.83.0-gitian.zip inputs/
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/qt-win32.yml
    cp build/out/qt-win32-4.7.4-gitian.zip inputs/
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-win32.yml

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -16,13 +16,13 @@ USE_UPNP:=0
 INCLUDEPATHS= \
  -I"$(CURDIR)" \
  -I"$(CURDIR)"/obj \
- -I"$(DEPSDIR)/boost_1_55_0" \
+ -I"$(DEPSDIR)/boost_1_83_0" \
  -I"$(DEPSDIR)/db-6.0.20/build_unix" \
  -I"$(DEPSDIR)/openssl-1.0.1f/include" \
  -I"$(DEPSDIR)"
 
 LIBPATHS= \
- -L"$(DEPSDIR)/boost_1_55_0/stage/lib" \
+ -L"$(DEPSDIR)/boost_1_83_0/stage/lib" \
  -L"$(DEPSDIR)/db-6.0.20/build_unix" \
  -L"$(DEPSDIR)/openssl-1.0.1f"
 


### PR DESCRIPTION
## Summary
- update Boost references to 1.83.0 across docs and build scripts
- keep Windows build files consistent with newer Boost

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549d526414833280d36661ce107cbb