### PR TITLE
Update Windows build instructions

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -12,7 +12,7 @@
 #                    (default: /usr/lib:/usr/local/bin)
 
 MXE_PREFIX=${MXE_PREFIX:-/mnt/mxe}
-MXE_TARGET=${MXE_TARGET:-i686-w64-mingw32.static}
+MXE_TARGET=${MXE_TARGET:-x86_64-w64-mingw32.static}
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 PROJECT_ROOT=${PROJECT_ROOT:-$SCRIPT_DIR}
 JOBS=${JOBS:-16}

--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -13,9 +13,9 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1b.tar.gz"
-- "db-4.8.30.NC.tar.gz"
-- "miniupnpc-1.6.tar.gz"
+ - "openssl-3.1.1.tar.gz"
+ - "db-6.2.38.tar.gz"
+ - "miniupnpc-2.2.4.tar.gz"
 - "zlib-1.2.7.tar.gz"
 - "libpng-1.5.12.tar.gz"
 - "qrencode-3.2.0.tar.bz2"
@@ -25,25 +25,25 @@ script: |
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
   #
-  tar xzf openssl-1.0.1b.tar.gz
-  cd openssl-1.0.1b
+  tar xzf openssl-3.1.1.tar.gz
+  cd openssl-3.1.1
   ./Configure --cross-compile-prefix=i586-mingw32msvc- mingw
   make
   cd ..
   #
-  tar xzf db-4.8.30.NC.tar.gz
-  cd db-4.8.30.NC/build_unix
+  tar xzf db-6.2.38.tar.gz
+  cd db-6.2.38/build_unix
   ../dist/configure --enable-mingw --enable-cxx --host=i586-mingw32msvc CFLAGS="-I/usr/i586-mingw32msvc/include"
   make $MAKEOPTS
   cd ../..
   #
-  tar xzf miniupnpc-1.6.tar.gz
-  cd miniupnpc-1.6
+  tar xzf miniupnpc-2.2.4.tar.gz
+  cd miniupnpc-2.2.4
   sed 's/dllwrap -k --driver-name gcc/$(DLLWRAP) -k --driver-name $(CC)/' -i Makefile.mingw
   sed 's|wingenminiupnpcstrings $< $@|./wingenminiupnpcstrings $< $@|' -i Makefile.mingw
   make -f Makefile.mingw DLLWRAP=i586-mingw32msvc-dllwrap CC=i586-mingw32msvc-gcc AR=i586-mingw32msvc-ar
   cd ..
-  mv miniupnpc-1.6 miniupnpc
+  mv miniupnpc-2.2.4 miniupnpc
   #
   tar xzf zlib-1.2.7.tar.gz
   cd zlib-1.2.7

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -51,7 +51,7 @@ script: |
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
-  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-4.8.30.NC/build_unix BDB_INCLUDE_PATH=$HOME/build/db-4.8.30.NC/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_83_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_83_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-1.0.1b OPENSSL_INCLUDE_PATH=$HOME/build/openssl-1.0.1b/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.2.0/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.2.0 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=ppcoin QMAKE_LFLAGS=-frandom-seed=ppcoin USE_BUILD_INFO=1
+  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-6.2.38/build_unix BDB_INCLUDE_PATH=$HOME/build/db-6.2.38/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_83_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_83_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-3.1.1 OPENSSL_INCLUDE_PATH=$HOME/build/openssl-3.1.1/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.2.0/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.2.0 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=ppcoin QMAKE_LFLAGS=-frandom-seed=ppcoin USE_BUILD_INFO=1
   make $MAKEOPTS
   cp release/ppcoin-qt.exe $OUTDIR/
   #

--- a/doc/build-msw.txt
+++ b/doc/build-msw.txt
@@ -24,10 +24,10 @@ Dependencies
 Libraries you need to download separately and build:
 
                 default path               download
-OpenSSL         \openssl-1.0.1b-mgw        https://www.openssl.org/source/
-Berkeley DB     \db-4.8.30.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
+OpenSSL         \openssl-3.1.1-mgw         https://www.openssl.org/source/
+Berkeley DB     \db-6.2.38-mgw             https://download.oracle.com/berkeley-db/
 Boost           \boost-1.83.0-mgw          http://www.boost.org/users/download/
-miniupnpc       \miniupnpc-1.6-mgw         https://miniupnp.tuxfamily.org/files/
+miniupnpc       \miniupnpc-2.2.4-mgw       https://miniupnp.tuxfamily.org/files/
 
 Their licenses:
 OpenSSL        Old BSD license with the problematic advertising requirement
@@ -36,10 +36,10 @@ Boost          MIT-like license
 miniupnpc      New (3-clause) BSD license
 
 Versions used in this release:
-OpenSSL      1.0.1b
-Berkeley DB  4.8.30.NC
+OpenSSL      3.1.1
+Berkeley DB  6.2.38
 Boost        1.83.0
-miniupnpc    1.6
+miniupnpc    2.2.4
 
 
 OpenSSL
@@ -48,14 +48,14 @@ MSYS shell:
 un-tar sources with MSYS 'tar xfz' to avoid issue with symlinks (OpenSSL ticket 2377)
 change 'MAKE' env. variable from 'C:\MinGW32\bin\mingw32-make.exe' to '/c/MinGW32/bin/mingw32-make.exe'
 
-cd /c/openssl-1.0.1b-mgw
+cd /c/openssl-3.1.1-mgw
 ./config
 make
 
 Berkeley DB
 -----------
 MSYS shell:
-cd /c/db-4.8.30.NC-mgw/build_unix
+cd /c/db-6.2.38-mgw/build_unix
 sh ../dist/configure --enable-mingw --enable-cxx
 make
 
@@ -71,7 +71,7 @@ MiniUPnPc
 UPnP support is optional, make with USE_UPNP= to disable it.
 
 MSYS shell:
-cd /c/miniupnpc-1.6-mgw
+cd /c/miniupnpc-2.2.4-mgw
 make -f Makefile.mingw
 mkdir miniupnpc
 cp *.h miniupnpc/

--- a/doc/release-process.txt
+++ b/doc/release-process.txt
@@ -23,9 +23,9 @@
 
   * Fetch and build inputs:
    mkdir -p inputs; cd inputs/
-   wget 'https://miniupnp.free.fr/files/download.php?file=miniupnpc-1.6.tar.gz' -O miniupnpc-1.6.tar.gz
-   wget 'https://www.openssl.org/source/openssl-1.0.1b.tar.gz'
-   wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
+  wget 'https://miniupnp.free.fr/files/download.php?file=miniupnpc-2.2.4.tar.gz' -O miniupnpc-2.2.4.tar.gz
+  wget 'https://www.openssl.org/source/openssl-3.1.1.tar.gz'
+  wget 'https://download.oracle.com/berkeley-db/db-6.2.38.tar.gz'
    wget 'http://zlib.net/zlib-1.2.6.tar.gz'
    wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.9.tar.gz'
    wget 'http://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -17,14 +17,14 @@ INCLUDEPATHS= \
  -I"$(CURDIR)" \
  -I"$(CURDIR)"/obj \
  -I"$(DEPSDIR)/boost_1_83_0" \
- -I"$(DEPSDIR)/db-6.0.20/build_unix" \
- -I"$(DEPSDIR)/openssl-1.0.1f/include" \
+ -I"$(DEPSDIR)/db-6.2.38/build_unix" \
+ -I"$(DEPSDIR)/openssl-3.1.1/include" \
  -I"$(DEPSDIR)"
 
 LIBPATHS= \
  -L"$(DEPSDIR)/boost_1_83_0/stage/lib" \
- -L"$(DEPSDIR)/db-6.0.20/build_unix" \
- -L"$(DEPSDIR)/openssl-1.0.1f"
+ -L"$(DEPSDIR)/db-6.2.38/build_unix" \
+ -L"$(DEPSDIR)/openssl-3.1.1"
 
 LIBS= \
  -l boost_system-mt \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -5,21 +5,21 @@
 USE_UPNP:=0
 
 INCLUDEPATHS= \
- -I"C:\boost-1.50.0-mgw" \
- -I"C:\db-4.8.30.NC-mgw\build_unix" \
- -I"C:\openssl-1.0.1c-mgw\include"
+ -I"C:\boost-1.83.0-mgw" \
+ -I"C:\db-6.2.38-mgw\build_unix" \
+ -I"C:\openssl-3.1.1-mgw\include"
 
 LIBPATHS= \
- -L"C:\boost-1.50.0-mgw\stage\lib" \
- -L"C:\db-4.8.30.NC-mgw\build_unix" \
- -L"C:\openssl-1.0.1c-mgw"
+ -L"C:\boost-1.83.0-mgw\stage\lib" \
+ -L"C:\db-6.2.38-mgw\build_unix" \
+ -L"C:\openssl-3.1.1-mgw"
 
 LIBS= \
- -l boost_system-mgw44-mt-1_53 \
- -l boost_filesystem-mgw44-mt-1_53 \
- -l boost_program_options-mgw44-mt-1_53 \
- -l boost_thread-mgw44-mt-1_53 \
- -l boost_chrono-mgw44-mt-1_53 \
+ -l boost_system-mt \
+ -l boost_filesystem-mt \
+ -l boost_program_options-mt \
+ -l boost_thread-mt \
+ -l boost_chrono-mt \
  -l db_cxx \
  -l ssl \
  -l crypto
@@ -35,8 +35,8 @@ ifndef USE_UPNP
 	override USE_UPNP = -
 endif
 ifneq (${USE_UPNP}, -)
- INCLUDEPATHS += -I"C:\miniupnpc-1.6-mgw"
- LIBPATHS += -L"C:\miniupnpc-1.6-mgw"
+ INCLUDEPATHS += -I"C:\miniupnpc-2.2.4-mgw"
+ LIBPATHS += -L"C:\miniupnpc-2.2.4-mgw"
  LIBS += -l miniupnpc -l iphlpapi
  DEFS += -DSTATICLIB -DUSE_UPNP=$(USE_UPNP)
 endif


### PR DESCRIPTION
## Summary
- modernize Windows dependency versions and build steps
- default cross-compilation target to 64-bit
- refresh gitian descriptors and makefiles for updated libs

## Testing
- `make -f makefile.unix` *(fails: boost headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549f6932788332a98021713db9fdf1