### PR TITLE
Remove OpenSSL from makefiles

### DIFF
--- a/src/makefile.bsd
+++ b/src/makefile.bsd
@@ -8,8 +8,8 @@ LINK:=$(CXX)
 
 DEFS=-DBOOST_SPIRIT_THREADSAFE
 
-DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH))
-LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(OPENSSL_LIB_PATH))
+DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH))
+LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH))
 
 LMODE = dynamic
 LMODE2 = dynamic
@@ -28,8 +28,6 @@ LIBS += \
    -l boost_program_options$(BOOST_LIB_SUFFIX) \
    -l boost_thread$(BOOST_LIB_SUFFIX) \
    -l db_cxx$(BDB_LIB_SUFFIX) \
-   -l ssl \
-   -l crypto \
    -l execinfo
 
 ifndef USE_UPNP

--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -1,31 +1,23 @@
 # Copyright (c) 2009-2010 Satoshi Nakamoto
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
 TARGET_PLATFORM:=i686
 #TARGET_PLATFORM:=x86_64
-
 DEPSDIR:=/usr/$(TARGET_PLATFORM)-w64-mingw32
 CC:=$(TARGET_PLATFORM)-w64-mingw32-gcc
 CXX:=$(TARGET_PLATFORM)-w64-mingw32-g++
 RANLIB=$(TARGET_PLATFORM)-w64-mingw32-ranlib
 STRIP=$(TARGET_PLATFORM)-w64-mingw32-strip
-
 USE_UPNP:=0
-
 INCLUDEPATHS= \
  -I"$(CURDIR)" \
  -I"$(CURDIR)"/obj \
  -I"$(DEPSDIR)/boost_1_83_0" \
  -I"$(DEPSDIR)/db-6.2.38/build_unix" \
- -I"$(DEPSDIR)/openssl-3.1.1/include" \
  -I"$(DEPSDIR)"
-
 LIBPATHS= \
  -L"$(DEPSDIR)/boost_1_83_0/stage/lib" \
  -L"$(DEPSDIR)/db-6.2.38/build_unix" \
- -L"$(DEPSDIR)/openssl-3.1.1"
-
 LIBS= \
  -l boost_system-mt \
  -l boost_filesystem-mt \
@@ -33,15 +25,11 @@ LIBS= \
  -l boost_thread_win32-mt \
  -l boost_chrono-mt \
  -l db_cxx \
- -l ssl \
- -l crypto \
  -l z
-
 DEFS=-D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
 DEBUGFLAGS=-g
 CFLAGS=-O3 -msse2 -w -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat -static-libgcc -static-libstdc++
-
 ifndef USE_UPNP
 	override USE_UPNP = -
 endif
@@ -50,12 +38,9 @@ ifneq (${USE_UPNP}, -)
 	LIBS += -l miniupnpc -l iphlpapi
 	DEFS += -DSTATICLIB -DUSE_UPNP=$(USE_UPNP)
 endif
-
 LIBS += -l mingwthrd -l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l winmm -l shell32 -l comctl32 -l ole32 -l oleaut32 -l uuid -l rpcrt4 -l advapi32 -l ws2_32 -l mswsock -l shlwapi
-
 # TODO: make the mingw builds smarter about dependencies, like the linux/osx builds are
 HEADERS = $(wildcard *.h)
-
 OBJS= \
     obj/alert.o \
     obj/version.o \
@@ -99,9 +84,7 @@ OBJS= \
     obj/zerocoin/SerialNumberSignatureOfKnowledge.o \
     obj/zerocoin/SpendMetaData.o \
     obj/zerocoin/ZeroTest.o
-
 all: Mousecoind.exe
-
 LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
 DEFS += -I"$(CURDIR)/leveldb/include"
 DEFS += -I"$(CURDIR)/leveldb/helpers"
@@ -109,33 +92,25 @@ OBJS += obj/txdb-leveldb.o
 leveldb/libleveldb.a:
 	@echo "Building LevelDB ..." && cd leveldb && CC=$(CC) CXX=$(CXX) TARGET_OS=OS_WINDOWS_CROSSCOMPILE CXXFLAGS="-I$(INCLUDEPATHS)" LDFLAGS="-L$(LIBPATHS)" $(MAKE) libleveldb.a libmemenv.a && $(RANLIB) libleveldb.a && $(RANLIB) libmemenv.a && cd ..
 obj/txdb-leveldb.o: leveldb/libleveldb.a
-
 obj/build.h: FORCE
 	/bin/sh ../share/genbuild.sh obj/build.h
 version.cpp: obj/build.h
 DEFS += -DHAVE_BUILD_INFO
-
 obj/%.o: %.cpp $(HEADERS)
 	$(CXX) -c $(CFLAGS) -o $@ $<
-
 obj/zerocoin/%.o: zerocoin/%.cpp $(HEADERS)
 	$(CXX) -c $(CFLAGS) -o $@ $<
-
 Mousecoind.exe: $(OBJS:obj/%=obj/%)
 	$(CXX) $(CFLAGS) $(LDFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS) -lshlwapi
 	$(STRIP) Mousecoind.exe
-
 obj/scrypt-x86.o: scrypt-x86.S
 	$(CXX) -c $(CFLAGS) -MMD -o $@ $<
-
 obj/scrypt-x86_64.o: scrypt-x86_64.S
 	$(CXX) -c $(CFLAGS) -MMD -o $@ $<
-
 clean:
 	-rm -f obj/*.o
 	-rm -f obj/zerocoin/*.o
 	-rm -f Mousecoind.exe
 	-rm -f obj/build.h
 	cd leveldb && TARGET_OS=OS_WINDOWS_CROSSCOMPILE $(MAKE) clean && cd ..
-
 FORCE:

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -1,19 +1,13 @@
 # Copyright (c) 2009-2010 Satoshi Nakamoto
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
 USE_UPNP:=0
-
 INCLUDEPATHS= \
  -I"C:\boost-1.83.0-mgw" \
  -I"C:\db-6.2.38-mgw\build_unix" \
- -I"C:\openssl-3.1.1-mgw\include"
-
 LIBPATHS= \
  -L"C:\boost-1.83.0-mgw\stage\lib" \
  -L"C:\db-6.2.38-mgw\build_unix" \
- -L"C:\openssl-3.1.1-mgw"
-
 LIBS= \
  -l boost_system-mt \
  -l boost_filesystem-mt \
@@ -21,16 +15,11 @@ LIBS= \
  -l boost_thread-mt \
  -l boost_chrono-mt \
  -l db_cxx \
- -l ssl \
- -l crypto
-
 DEFS=-DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -DBOOST_SPIRIT_THREADSAFE
 DEBUGFLAGS=-g
 CFLAGS=-mthreads -O3 -msse2 -w -Wall -Wextra -Wno-ignored-qualifiers -Wformat -Wformat-security -Wno-unused-parameter $(DEBUGFLAGS) $(DEFS) $(INCLUDEPATHS)
 LDFLAGS=-Wl,--dynamicbase -Wl,--nxcompat
-
 TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
-
 ifndef USE_UPNP
 	override USE_UPNP = -
 endif
@@ -40,12 +29,9 @@ ifneq (${USE_UPNP}, -)
  LIBS += -l miniupnpc -l iphlpapi
  DEFS += -DSTATICLIB -DUSE_UPNP=$(USE_UPNP)
 endif
-
 LIBS += -l kernel32 -l user32 -l gdi32 -l comdlg32 -l winspool -l winmm -l shell32 -l comctl32 -l ole32 -l oleaut32 -l uuid -l rpcrt4 -l advapi32 -l ws2_32 -l mswsock -l shlwapi
-
 # TODO: make the mingw builds smarter about dependencies, like the linux/osx builds are
 HEADERS = $(wildcard *.h)
-
 OBJS= \
     obj/alert.o \
     obj/version.o \
@@ -89,9 +75,7 @@ OBJS= \
     obj/zerocoin/SerialNumberSignatureOfKnowledge.o \
     obj/zerocoin/SpendMetaData.o \
     obj/zerocoin/ZeroTest.o
-
 all: Mousecoind.exe
-
 LIBS += $(CURDIR)/leveldb/libleveldb.a $(CURDIR)/leveldb/libmemenv.a
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
@@ -99,25 +83,18 @@ OBJS += obj/txdb-leveldb.o
 leveldb/libleveldb.a:
 	cd leveldb; make; cd ..
 obj/txdb-leveldb.o: leveldb/libleveldb.a
-
 obj/%.o: %.cpp $(HEADERS)
 	g++ -c $(CFLAGS) -o $@ $<
-
 obj/zerocoin/%.o: zerocoin/%.cpp
 	g++ -c $(CFLAGS) -o $@ $<
-
 obj/scrypt-x86.o: scrypt-x86.S
 	$(CXX) -c $(xCXXFLAGS) -MMD -o $@ $<
-
 obj/scrypt-x86_64.o: scrypt-x86_64.S
 	$(CXX) -c $(xCXXFLAGS) -MMD -o $@ $<
-
 Mousecoind.exe: $(OBJS:obj/%=obj/%)
 	g++ $(CFLAGS) $(LDFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
-
 clean:
 	-del /Q Mousecoind
 	-del /Q obj\*
 	-del /Q obj\zerocoin\*
-
 FORCE:

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -31,8 +31,6 @@ LIBS += \
  $(DEPSDIR)/lib/libboost_filesystem-mt.a \
  $(DEPSDIR)/lib/libboost_program_options-mt.a \
  $(DEPSDIR)/lib/libboost_thread-mt.a \
- $(DEPSDIR)/lib/libssl.a \
- $(DEPSDIR)/lib/libcrypto.a \
  -lz
 else
 LIBS += \
@@ -41,8 +39,6 @@ LIBS += \
  -lboost_filesystem-mt \
  -lboost_program_options-mt \
  -lboost_thread-mt \
- -lssl \
- -lcrypto \
  -lz
 endif
 

--- a/src/makefile.rpi
+++ b/src/makefile.rpi
@@ -4,8 +4,6 @@
 
 BOOST_LIB_PATH := /opt/x-tools/rpi/lib
 BOOST_INCLUDE_PATH := /opt/x-tools/rpi/include
-OPENSSL_LIB_PATH := /opt/x-tools/rpi/lib
-OPENSSL_INCLUDE_PATH := /opt/x-tools/rpi/include
 BDB_LIB_PATH := /opt/x-tools/rpi/lib
 BDB_INCLUDE_PATH := /opt/x-tools/rpi/include
 CXX_LIB_PATH := /opt/x-tools/pi-crosstool-ng/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/lib
@@ -26,9 +24,9 @@ ARCH := $(shell lscpu | head -n 1 | awk '{print $$2}')
 
 DEFS=-DBOOST_SPIRIT_THREADSAFE
 
-DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH) $(CXX_INCLUDE_PATH))
+DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(CXX_INCLUDE_PATH))
 DEFS += -DALLOW_BURN
-LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(OPENSSL_LIB_PATH) $(ZLIB_LIB_PATH))
+LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(ZLIB_LIB_PATH))
 
 LMODE = dynamic
 LMODE2 = dynamic
@@ -46,9 +44,7 @@ LIBS += \
    -l boost_filesystem$(BOOST_LIB_SUFFIX) \
    -l boost_program_options$(BOOST_LIB_SUFFIX) \
    -l boost_thread$(BOOST_LIB_SUFFIX) \
-   -l db_cxx$(BDB_LIB_SUFFIX) \
-   -l ssl \
-   -l crypto
+   -l db_cxx$(BDB_LIB_SUFFIX)
 
 ifndef USE_UPNP
 	override USE_UPNP = -

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -9,9 +9,9 @@ ARCH := $(shell uname -m)
 
 DEFS=-DBOOST_SPIRIT_THREADSAFE
 
-DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH) $(OPENSSL_INCLUDE_PATH))
+DEFS += $(addprefix -I,$(CURDIR) $(CURDIR)/obj $(BOOST_INCLUDE_PATH) $(BDB_INCLUDE_PATH))
 DEFS += -DALLOW_BURN
-LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH) $(OPENSSL_LIB_PATH))
+LIBS = $(addprefix -L,$(BOOST_LIB_PATH) $(BDB_LIB_PATH))
 
 LMODE = dynamic
 LMODE2 = dynamic
@@ -29,9 +29,7 @@ LIBS += \
    -l boost_filesystem$(BOOST_LIB_SUFFIX) \
    -l boost_program_options$(BOOST_LIB_SUFFIX) \
    -l boost_thread$(BOOST_LIB_SUFFIX) \
-   -l db_cxx$(BDB_LIB_SUFFIX) \
-   -l ssl \
-   -l crypto
+   -l db_cxx$(BDB_LIB_SUFFIX)
 
 ifndef USE_UPNP
 	override USE_UPNP = -


### PR DESCRIPTION
## Summary
- drop `-lssl` and `-lcrypto` from all platform makefiles
- drop OpenSSL include/library path usage
- remove unused OpenSSL variables in the Raspberry Pi makefile

## Testing
- `make -f makefile.unix` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854aedf4d20833299b97b69c5cad1f1