### PR TITLE
Replace OpenSSL SHA256 with internal implementation

### DIFF
--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -1,0 +1,57 @@
+#ifndef BITCOIN_CRYPTO_COMMON_H
+#define BITCOIN_CRYPTO_COMMON_H
+
+#include <stdint.h>
+#include <string.h>
+
+static inline uint32_t ReadLE32(const unsigned char* ptr)
+{
+    return ((uint32_t)ptr[0]) | ((uint32_t)ptr[1] << 8) |
+           ((uint32_t)ptr[2] << 16) | ((uint32_t)ptr[3] << 24);
+}
+
+static inline uint64_t ReadLE64(const unsigned char* ptr)
+{
+    return ((uint64_t)ReadLE32(ptr)) | ((uint64_t)ReadLE32(ptr + 4) << 32);
+}
+
+static inline void WriteLE32(unsigned char* ptr, uint32_t x)
+{
+    ptr[0] = x;
+    ptr[1] = x >> 8;
+    ptr[2] = x >> 16;
+    ptr[3] = x >> 24;
+}
+
+static inline void WriteLE64(unsigned char* ptr, uint64_t x)
+{
+    WriteLE32(ptr, x & 0xffffffff);
+    WriteLE32(ptr + 4, x >> 32);
+}
+
+static inline uint32_t ReadBE32(const unsigned char* ptr)
+{
+    return ((uint32_t)ptr[3]) | ((uint32_t)ptr[2] << 8) |
+           ((uint32_t)ptr[1] << 16) | ((uint32_t)ptr[0] << 24);
+}
+
+static inline uint64_t ReadBE64(const unsigned char* ptr)
+{
+    return ((uint64_t)ReadBE32(ptr) << 32) | ReadBE32(ptr + 4);
+}
+
+static inline void WriteBE32(unsigned char* ptr, uint32_t x)
+{
+    ptr[3] = x;
+    ptr[2] = x >> 8;
+    ptr[1] = x >> 16;
+    ptr[0] = x >> 24;
+}
+
+static inline void WriteBE64(unsigned char* ptr, uint64_t x)
+{
+    WriteBE32(ptr, x >> 32);
+    WriteBE32(ptr + 4, x & 0xffffffff);
+}
+
+#endif // BITCOIN_CRYPTO_COMMON_H

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -1,0 +1,103 @@
+#include "sha256.h"
+#include "common.h"
+#include <string.h>
+
+static const uint32_t K[64] = {
+    0x428a2f98ul, 0x71374491ul, 0xb5c0fbcful, 0xe9b5dba5ul,
+    0x3956c25bul, 0x59f111f1ul, 0x923f82a4ul, 0xab1c5ed5ul,
+    0xd807aa98ul, 0x12835b01ul, 0x243185beul, 0x550c7dc3ul,
+    0x72be5d74ul, 0x80deb1feul, 0x9bdc06a7ul, 0xc19bf174ul,
+    0xe49b69c1ul, 0xefbe4786ul, 0x0fc19dc6ul, 0x240ca1ccul,
+    0x2de92c6ful, 0x4a7484aaul, 0x5cb0a9dcul, 0x76f988daul,
+    0x983e5152ul, 0xa831c66dul, 0xb00327c8ul, 0xbf597fc7ul,
+    0xc6e00bf3ul, 0xd5a79147ul, 0x06ca6351ul, 0x14292967ul,
+    0x27b70a85ul, 0x2e1b2138ul, 0x4d2c6dfcul, 0x53380d13ul,
+    0x650a7354ul, 0x766a0abbul, 0x81c2c92eul, 0x92722c85ul,
+    0xa2bfe8a1ul, 0xa81a664bul, 0xc24b8b70ul, 0xc76c51a3ul,
+    0xd192e819ul, 0xd6990624ul, 0xf40e3585ul, 0x106aa070ul,
+    0x19a4c116ul, 0x1e376c08ul, 0x2748774cul, 0x34b0bcb5ul,
+    0x391c0cb3ul, 0x4ed8aa4aul, 0x5b9cca4ful, 0x682e6ff3ul,
+    0x748f82eeul, 0x78a5636ful, 0x84c87814ul, 0x8cc70208ul,
+    0x90befffaul, 0xa4506cebul, 0xbef9a3f7ul, 0xc67178f2ul
+};
+
+#define ROTR(x,n) ((x>>n) | (x<<(32-n)))
+#define Ch(x,y,z) ((x & y) ^ (~x & z))
+#define Maj(x,y,z) ((x & y) ^ (x & z) ^ (y & z))
+#define Sigma0(x) (ROTR(x,2) ^ ROTR(x,13) ^ ROTR(x,22))
+#define Sigma1(x) (ROTR(x,6) ^ ROTR(x,11) ^ ROTR(x,25))
+#define sigma0(x) (ROTR(x,7) ^ ROTR(x,18) ^ ((x)>>3))
+#define sigma1(x) (ROTR(x,17) ^ ROTR(x,19) ^ ((x)>>10))
+
+void SHA256Transform(uint32_t state[8], const unsigned char block[64])
+{
+    uint32_t a,b,c,d,e,f,g,h,t1,t2,w[64];
+    for (int i = 0; i < 16; i++) {
+        w[i] = ReadBE32(block + 4*i);
+    }
+    for (int i = 16; i < 64; i++) {
+        w[i] = sigma1(w[i-2]) + w[i-7] + sigma0(w[i-15]) + w[i-16];
+    }
+    a=state[0]; b=state[1]; c=state[2]; d=state[3];
+    e=state[4]; f=state[5]; g=state[6]; h=state[7];
+    for (int i = 0; i < 64; i++) {
+        t1 = h + Sigma1(e) + Ch(e,f,g) + K[i] + w[i];
+        t2 = Sigma0(a) + Maj(a,b,c);
+        h = g; g = f; f = e; e = d + t1;
+        d = c; c = b; b = a; a = t1 + t2;
+    }
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    state[5] += f;
+    state[6] += g;
+    state[7] += h;
+}
+
+CSHA256::CSHA256() { Reset(); }
+
+CSHA256& CSHA256::Write(const unsigned char* data, size_t len)
+{
+    size_t bufsize = bytes % 64;
+    bytes += len;
+    if (bufsize && bufsize + len >= 64) {
+        memcpy(buf + bufsize, data, 64 - bufsize);
+        SHA256Transform(s, buf);
+        data += 64 - bufsize;
+        len -= 64 - bufsize;
+        bufsize = 0;
+    }
+    while (len >= 64) {
+        SHA256Transform(s, data);
+        data += 64;
+        len -= 64;
+    }
+    if (len) memcpy(buf + bufsize, data, len);
+    return *this;
+}
+
+void CSHA256::Finalize(unsigned char hash[OUTPUT_SIZE])
+{
+    static const unsigned char pad[64] = {0x80};
+    unsigned char sizedesc[8];
+    WriteBE64(sizedesc, bytes << 3);
+    Write(pad, 1 + ((119 - bytes) % 64));
+    Write(sizedesc, 8);
+    for (int i = 0; i < 8; i++) WriteBE32(hash + 4*i, s[i]);
+}
+
+CSHA256& CSHA256::Reset()
+{
+    bytes = 0;
+    s[0] = 0x6a09e667ul;
+    s[1] = 0xbb67ae85ul;
+    s[2] = 0x3c6ef372ul;
+    s[3] = 0xa54ff53aul;
+    s[4] = 0x510e527ful;
+    s[5] = 0x9b05688cul;
+    s[6] = 0x1f83d9abul;
+    s[7] = 0x5be0cd19ul;
+    return *this;
+}

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -1,0 +1,49 @@
+#ifndef BITCOIN_CRYPTO_SHA256_H
+#define BITCOIN_CRYPTO_SHA256_H
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stddef.h>
+
+class CSHA256
+{
+private:
+    uint32_t s[8];
+    unsigned char buf[64];
+    uint64_t bytes;
+
+public:
+    static const size_t OUTPUT_SIZE = 32;
+
+    CSHA256();
+    CSHA256& Write(const unsigned char* data, size_t len);
+    void Finalize(unsigned char hash[OUTPUT_SIZE]);
+    CSHA256& Reset();
+};
+
+class CHash256
+{
+private:
+    CSHA256 sha;
+public:
+    static const size_t OUTPUT_SIZE = CSHA256::OUTPUT_SIZE;
+
+    CHash256& Write(const unsigned char* data, size_t len) {
+        sha.Write(data, len);
+        return *this;
+    }
+    void Finalize(unsigned char hash[OUTPUT_SIZE]) {
+        unsigned char buf[OUTPUT_SIZE];
+        sha.Finalize(buf);
+        sha.Reset();
+        sha.Write(buf, OUTPUT_SIZE).Finalize(hash);
+    }
+    CHash256& Reset() {
+        sha.Reset();
+        return *this;
+    }
+};
+
+void SHA256Transform(uint32_t state[8], const unsigned char block[64]);
+
+#endif // BITCOIN_CRYPTO_SHA256_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -7,6 +7,7 @@
 #include "txdb.h"
 #include "miner.h"
 #include "kernel.h"
+#include "crypto/sha256.h"
 #include <memory>
 
 using namespace std;
@@ -38,20 +39,18 @@ static const unsigned int pSHA256InitState[8] =
 
 void SHA256Transform(void* pstate, void* pinput, const void* pinit)
 {
-    SHA256_CTX ctx;
+    uint32_t state[8];
     unsigned char data[64];
-
-    SHA256_Init(&ctx);
 
     for (int i = 0; i < 16; i++)
         ((uint32_t*)data)[i] = ByteReverse(((uint32_t*)pinput)[i]);
 
     for (int i = 0; i < 8; i++)
-        ctx.h[i] = ((uint32_t*)pinit)[i];
+        state[i] = ((const uint32_t*)pinit)[i];
 
-    SHA256_Update(&ctx, data, sizeof(data));
+    ::SHA256Transform(state, data);
     for (int i = 0; i < 8; i++)
-        ((uint32_t*)pstate)[i] = ctx.h[i];
+        ((uint32_t*)pstate)[i] = state[i];
 }
 
 // Some explaining would be appreciated

--- a/src/pbkdf2.cpp
+++ b/src/pbkdf2.cpp
@@ -36,26 +36,24 @@ HMAC_SHA256_Init(HMAC_SHA256_CTX * ctx, const void * _K, size_t Klen)
 
     /* If Klen > 64, the key is really SHA256(K). */
     if (Klen > 64) {
-        SHA256_Init(&ctx->ictx);
-        SHA256_Update(&ctx->ictx, K, Klen);
-        SHA256_Final(khash, &ctx->ictx);
+        CSHA256().Write(K, Klen).Finalize(khash);
         K = khash;
         Klen = 32;
     }
 
     /* Inner SHA256 operation is SHA256(K xor [block of 0x36] || data). */
-    SHA256_Init(&ctx->ictx);
+    ctx->ictx.Reset();
     memset(pad, 0x36, 64);
     for (i = 0; i < Klen; i++)
         pad[i] ^= K[i];
-    SHA256_Update(&ctx->ictx, pad, 64);
+    ctx->ictx.Write(pad, 64);
 
     /* Outer SHA256 operation is SHA256(K xor [block of 0x5c] || hash). */
-    SHA256_Init(&ctx->octx);
+    ctx->octx.Reset();
     memset(pad, 0x5c, 64);
     for (i = 0; i < Klen; i++)
         pad[i] ^= K[i];
-    SHA256_Update(&ctx->octx, pad, 64);
+    ctx->octx.Write(pad, 64);
 
     /* Clean the stack. */
     memset(khash, 0, 32);
@@ -67,7 +65,7 @@ HMAC_SHA256_Update(HMAC_SHA256_CTX * ctx, const void *in, size_t len)
 {
 
     /* Feed data to the inner SHA256 operation. */
-    SHA256_Update(&ctx->ictx, in, len);
+    ctx->ictx.Write((const unsigned char*)in, len);
 }
 
 /* Finish an HMAC-SHA256 operation. */
@@ -77,13 +75,13 @@ HMAC_SHA256_Final(unsigned char digest[32], HMAC_SHA256_CTX * ctx)
     unsigned char ihash[32];
 
     /* Finish the inner SHA256 operation. */
-    SHA256_Final(ihash, &ctx->ictx);
+    ctx->ictx.Finalize(ihash);
 
     /* Feed the inner hash to the outer SHA256 operation. */
-    SHA256_Update(&ctx->octx, ihash, 32);
+    ctx->octx.Write(ihash, 32);
 
     /* Finish the outer SHA256 operation. */
-    SHA256_Final(digest, &ctx->octx);
+    ctx->octx.Finalize(digest);
 
     /* Clean the stack. */
     memset(ihash, 0, 32);

--- a/src/pbkdf2.h
+++ b/src/pbkdf2.h
@@ -3,12 +3,12 @@
 #ifndef PBKDF2_H
 #define PBKDF2_H
 
-#include <openssl/sha.h>
+#include "crypto/sha256.h"
 #include <stdint.h>
 
 typedef struct HMAC_SHA256Context {
-    SHA256_CTX ictx;
-    SHA256_CTX octx;
+    CSHA256 ictx;
+    CSHA256 octx;
 } HMAC_SHA256_CTX;
 
 void

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -969,7 +969,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                     else if (opcode == OP_SHA1)
                         SHA1(&vch[0], vch.size(), &vchHash[0]);
                     else if (opcode == OP_SHA256)
-                        SHA256(&vch[0], vch.size(), &vchHash[0]);
+                        CSHA256().Write(&vch[0], vch.size()).Finalize(&vchHash[0]);
                     else if (opcode == OP_HASH160)
                     {
                         uint160 hash160 = Hash160(vch);


### PR DESCRIPTION
## Summary
- add Bitcoin's `CSHA256` implementation under `src/crypto/`
- switch util code and PBKDF2 to use `CSHA256`
- update mining and scripting logic to use the new hashing routines

## Testing
- `make -f makefile.unix` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854aece298083328e15bce65fca81ce