### PR TITLE
Add cctype include to base58

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <vector>
+#include <cctype>
 #include "bignum.h"
 #include "key.h"
 #include "script.h"


### PR DESCRIPTION
## Summary
- include `<cctype>` in `base58.h`

## Testing
- `make -f makefile.unix` *(fails: boost headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b467c7e08332b91d7e0cd1a8b536