### PR TITLE
Use libsecp256k1 for key recovery

### DIFF
--- a/Mic3.pro
+++ b/Mic3.pro
@@ -419,8 +419,8 @@ macx:QMAKE_CXXFLAGS_THREAD += -pthread
 
 # Set libraries and includes at end, to use platform-defined defaults if not overridden
 INCLUDEPATH += $$BOOST_INCLUDE_PATH $$BDB_INCLUDE_PATH $$OPENSSL_INCLUDE_PATH $$QRENCODE_INCLUDE_PATH
-LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB_PATH,,-L,) $$join(QRENCODE_LIB_PATH,,-L,)
-LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX
+LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB_PATH,,-L,) $$join(QRENCODE_LIB_PATH,,-L,) $$join(SECP256K1_LIB_PATH,,-L,)
+LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX -lsecp256k1
 # -lgdi32 has to happen after -lcrypto (see  #681)
 windows:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
 LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX

--- a/compile.sh
+++ b/compile.sh
@@ -32,6 +32,7 @@ cd ../..
         BOOST_THREAD_LIB_SUFFIX=_win32-mt \
         BOOST_INCLUDE_PATH="$MXE_PREFIX/usr/$MXE_TARGET/include/boost" \
         BOOST_LIB_PATH="$MXE_PREFIX/usr/$MXE_TARGET/lib" \
+        SECP256K1_LIB_PATH="$SECP256K1_LIB_PATH" \
         OPENSSL_INCLUDE_PATH="$MXE_PREFIX/usr/$MXE_TARGET/include/openssl" \
         OPENSSL_LIB_PATH="$MXE_PREFIX/usr/$MXE_TARGET/lib" \
         BDB_INCLUDE_PATH="$MXE_PREFIX/usr/$MXE_TARGET/include" \

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -6,44 +6,41 @@
 
 #include <openssl/ecdsa.h>
 #include <openssl/obj_mac.h>
+#include <secp256k1.h>
+#include <secp256k1_recovery.h>
 
 #include "key.h"
+
+static secp256k1_context* secp256k1_ctx = NULL;
+
+static void ensure_secp256k1_init() {
+    if (secp256k1_ctx == NULL) {
+        secp256k1_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    }
+}
 
 // Generate a private key from just the secret parameter
 int EC_KEY_regenerate_key(EC_KEY *eckey, BIGNUM *priv_key)
 {
-    int ok = 0;
-    BN_CTX *ctx = NULL;
-    EC_POINT *pub_key = NULL;
-
     if (!eckey) return 0;
+    ensure_secp256k1_init();
 
-    const EC_GROUP *group = EC_KEY_get0_group(eckey);
+    unsigned char seckey[32];
+    if (!BN_bn2binpad(priv_key, seckey, sizeof(seckey)))
+        return 0;
 
-    if ((ctx = BN_CTX_new()) == NULL)
-        goto err;
+    secp256k1_pubkey pubkey;
+    if (!secp256k1_ec_pubkey_create(secp256k1_ctx, &pubkey, seckey))
+        return 0;
 
-    pub_key = EC_POINT_new(group);
-
-    if (pub_key == NULL)
-        goto err;
-
-    if (!EC_POINT_mul(group, pub_key, priv_key, NULL, NULL, ctx))
-        goto err;
-
-    EC_KEY_set_private_key(eckey,priv_key);
-    EC_KEY_set_public_key(eckey,pub_key);
-
-    ok = 1;
-
-err:
-
-    if (pub_key)
-        EC_POINT_free(pub_key);
-    if (ctx != NULL)
-        BN_CTX_free(ctx);
-
-    return(ok);
+    unsigned char pub[65];
+    size_t publen = sizeof(pub);
+    secp256k1_ec_pubkey_serialize(secp256k1_ctx, pub, &publen, &pubkey, SECP256K1_EC_UNCOMPRESSED);
+    const unsigned char* pbegin = pub;
+    EC_KEY_set_private_key(eckey, priv_key);
+    if (o2i_ECPublicKey(&eckey, &pbegin, publen) == NULL)
+        return 0;
+    return 1;
 }
 
 // Perform ECDSA key recovery (see SEC1 4.1.6) for curves over (mod p)-fields
@@ -52,72 +49,27 @@ err:
 int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned char *msg, int msglen, int recid, int check)
 {
     if (!eckey) return 0;
+    ensure_secp256k1_init();
 
-    int ret = 0;
-    BN_CTX *ctx = NULL;
+    unsigned char compact_sig[64];
+    if (!BN_bn2binpad(ecsig->r, compact_sig, 32)) return 0;
+    if (!BN_bn2binpad(ecsig->s, compact_sig + 32, 32)) return 0;
 
-    BIGNUM *x = NULL;
-    BIGNUM *e = NULL;
-    BIGNUM *order = NULL;
-    BIGNUM *sor = NULL;
-    BIGNUM *eor = NULL;
-    BIGNUM *field = NULL;
-    EC_POINT *R = NULL;
-    EC_POINT *O = NULL;
-    EC_POINT *Q = NULL;
-    BIGNUM *rr = NULL;
-    BIGNUM *zero = NULL;
-    int n = 0;
-    int i = recid / 2;
+    secp256k1_ecdsa_recoverable_signature sig;
+    if (!secp256k1_ecdsa_recoverable_signature_parse_compact(secp256k1_ctx, &sig, compact_sig, recid))
+        return 0;
 
-    const EC_GROUP *group = EC_KEY_get0_group(eckey);
-    if ((ctx = BN_CTX_new()) == NULL) { ret = -1; goto err; }
-    BN_CTX_start(ctx);
-    order = BN_CTX_get(ctx);
-    if (!EC_GROUP_get_order(group, order, ctx)) { ret = -2; goto err; }
-    x = BN_CTX_get(ctx);
-    if (!BN_copy(x, order)) { ret=-1; goto err; }
-    if (!BN_mul_word(x, i)) { ret=-1; goto err; }
-    if (!BN_add(x, x, ecsig->r)) { ret=-1; goto err; }
-    field = BN_CTX_get(ctx);
-    if (!EC_GROUP_get_curve_GFp(group, field, NULL, NULL, ctx)) { ret=-2; goto err; }
-    if (BN_cmp(x, field) >= 0) { ret=0; goto err; }
-    if ((R = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
-    if (!EC_POINT_set_compressed_coordinates_GFp(group, R, x, recid % 2, ctx)) { ret=0; goto err; }
-    if (check)
-    {
-        if ((O = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
-        if (!EC_POINT_mul(group, O, NULL, R, order, ctx)) { ret=-2; goto err; }
-        if (!EC_POINT_is_at_infinity(group, O)) { ret = 0; goto err; }
-    }
-    if ((Q = EC_POINT_new(group)) == NULL) { ret = -2; goto err; }
-    n = EC_GROUP_get_degree(group);
-    e = BN_CTX_get(ctx);
-    if (!BN_bin2bn(msg, msglen, e)) { ret=-1; goto err; }
-    if (8*msglen > n) BN_rshift(e, e, 8-(n & 7));
-    zero = BN_CTX_get(ctx);
-    if (!BN_zero(zero)) { ret=-1; goto err; }
-    if (!BN_mod_sub(e, zero, e, order, ctx)) { ret=-1; goto err; }
-    rr = BN_CTX_get(ctx);
-    if (!BN_mod_inverse(rr, ecsig->r, order, ctx)) { ret=-1; goto err; }
-    sor = BN_CTX_get(ctx);
-    if (!BN_mod_mul(sor, ecsig->s, rr, order, ctx)) { ret=-1; goto err; }
-    eor = BN_CTX_get(ctx);
-    if (!BN_mod_mul(eor, e, rr, order, ctx)) { ret=-1; goto err; }
-    if (!EC_POINT_mul(group, Q, eor, R, sor, ctx)) { ret=-2; goto err; }
-    if (!EC_KEY_set_public_key(eckey, Q)) { ret=-2; goto err; }
+    secp256k1_pubkey pubkey;
+    if (!secp256k1_ecdsa_recover(secp256k1_ctx, &pubkey, &sig, msg))
+        return 0;
 
-    ret = 1;
-
-err:
-    if (ctx) {
-        BN_CTX_end(ctx);
-        BN_CTX_free(ctx);
-    }
-    if (R != NULL) EC_POINT_free(R);
-    if (O != NULL) EC_POINT_free(O);
-    if (Q != NULL) EC_POINT_free(Q);
-    return ret;
+    unsigned char pub[65];
+    size_t publen = sizeof(pub);
+    secp256k1_ec_pubkey_serialize(secp256k1_ctx, pub, &publen, &pubkey, SECP256K1_EC_UNCOMPRESSED);
+    const unsigned char* pbegin = pub;
+    if (o2i_ECPublicKey(&eckey, &pbegin, publen) == NULL)
+        return 0;
+    return 1;
 }
 
 void CKey::SetCompressedPubKey()
@@ -462,6 +414,7 @@ bool CKey::IsValid()
 }
 
 bool ECC_InitSanityCheck() {
+    ensure_secp256k1_init();
     EC_KEY *pkey = EC_KEY_new_by_curve_name(NID_secp256k1);
     if(pkey == NULL)
         return false;

--- a/src/key.h
+++ b/src/key.h
@@ -14,6 +14,8 @@
 #include "util.h"
 
 #include <openssl/ec.h> // for EC_KEY definition
+#include <secp256k1.h>
+#include <secp256k1_recovery.h>
 
 // secp160k1
 // const unsigned int PRIVATE_KEY_SIZE = 192;

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -41,9 +41,10 @@ endif
 
 LIBS+= \
  -Wl,-B$(LMODE2) \
-   -l z \
-   -l dl \
-   -l pthread
+  -lsecp256k1 \
+  -l z \
+  -l dl \
+  -l pthread
 
 
 # Hardening


### PR DESCRIPTION
## Summary
- switch key implementation to use libsecp256k1
- link secp256k1 in qmake project and makefile
- expose secp256k1 libraries in compile script

## Testing
- `make -f makefile.unix` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854b74aac508332ae41e7f0883de05f