### PR TITLE
Update bignum tests for cpp_int wrapper

### DIFF
--- a/src/test/bignum_tests.cpp
+++ b/src/test/bignum_tests.cpp
@@ -1,8 +1,16 @@
 #include <boost/test/unit_test.hpp>
 #include <limits>
+#include <boost/multiprecision/cpp_int.hpp>
 
 #include "bignum.h"
-#include "util.h"
+
+using boost::multiprecision::cpp_int;
+
+static std::string IntToString(int64 n)
+{
+    cpp_int value = n;
+    return value.convert_to<std::string>();
+}
 
 BOOST_AUTO_TEST_SUITE(bignum_tests)
 
@@ -60,65 +68,65 @@ BOOST_AUTO_TEST_CASE(bignum_setint64)
     {
         n = 0;
         CBigNum num(n);
-        BOOST_CHECK(num.ToString() == "0");
+        BOOST_CHECK(num.ToString() == IntToString(n));
         num.setulong(0);
         BOOST_CHECK(num.ToString() == "0");
         mysetint64(num, n);
-        BOOST_CHECK(num.ToString() == "0");
+        BOOST_CHECK(num.ToString() == IntToString(n));
     }
     {
         n = 1;
         CBigNum num(n);
-        BOOST_CHECK(num.ToString() == "1");
+        BOOST_CHECK(num.ToString() == IntToString(n));
         num.setulong(0);
         BOOST_CHECK(num.ToString() == "0");
         mysetint64(num, n);
-        BOOST_CHECK(num.ToString() == "1");
+        BOOST_CHECK(num.ToString() == IntToString(n));
     }
     {
         n = -1;
         CBigNum num(n);
-        BOOST_CHECK(num.ToString() == "-1");
+        BOOST_CHECK(num.ToString() == IntToString(n));
         num.setulong(0);
         BOOST_CHECK(num.ToString() == "0");
         mysetint64(num, n);
-        BOOST_CHECK(num.ToString() == "-1");
+        BOOST_CHECK(num.ToString() == IntToString(n));
     }
     {
         n = 5;
         CBigNum num(n);
-        BOOST_CHECK(num.ToString() == "5");
+        BOOST_CHECK(num.ToString() == IntToString(n));
         num.setulong(0);
         BOOST_CHECK(num.ToString() == "0");
         mysetint64(num, n);
-        BOOST_CHECK(num.ToString() == "5");
+        BOOST_CHECK(num.ToString() == IntToString(n));
     }
     {
         n = -5;
         CBigNum num(n);
-        BOOST_CHECK(num.ToString() == "-5");
+        BOOST_CHECK(num.ToString() == IntToString(n));
         num.setulong(0);
         BOOST_CHECK(num.ToString() == "0");
         mysetint64(num, n);
-        BOOST_CHECK(num.ToString() == "-5");
+        BOOST_CHECK(num.ToString() == IntToString(n));
     }
     {
         n = std::numeric_limits<int64>::min();
         CBigNum num(n);
-        BOOST_CHECK(num.ToString() == "-9223372036854775808");
+        BOOST_CHECK(num.ToString() == IntToString(n));
         num.setulong(0);
         BOOST_CHECK(num.ToString() == "0");
         mysetint64(num, n);
-        BOOST_CHECK(num.ToString() == "-9223372036854775808");
+        BOOST_CHECK(num.ToString() == IntToString(n));
     }
     {
         n = std::numeric_limits<int64>::max();
         CBigNum num(n);
-        BOOST_CHECK(num.ToString() == "9223372036854775807");
+        BOOST_CHECK(num.ToString() == IntToString(n));
         num.setulong(0);
         BOOST_CHECK(num.ToString() == "0");
         mysetint64(num, n);
-        BOOST_CHECK(num.ToString() == "9223372036854775807");
+        BOOST_CHECK(num.ToString() == IntToString(n));
     }
 }
 


### PR DESCRIPTION
## Summary
- test suite `bignum_tests.cpp` now expects output matching boost::multiprecision `cpp_int`
- incorporate helper to convert integers via `cpp_int`

## Testing
- `make -f makefile.unix test_bitcoin` *(fails: No rule to make target)*
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bd7e7f5c8332b84690b342326504