### PR TITLE
Switch base58 to new big number API

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -27,7 +27,6 @@ static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnop
 // Encode a byte sequence as a base58-encoded string
 inline std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
 {
-    CAutoBN_CTX pctx;
     CBigNum bn58 = 58;
     CBigNum bn0 = 0;
 
@@ -45,13 +44,11 @@ inline std::string EncodeBase58(const unsigned char* pbegin, const unsigned char
     // Expected size increase from base58 conversion is approximately 137%
     // use 138% to be safe
     str.reserve((pend - pbegin) * 138 / 100 + 1);
-    CBigNum dv;
     CBigNum rem;
     while (bn > bn0)
     {
-        if (!BN_div(dv.bn, rem.bn, bn.bn, bn58.bn, pctx))
-            throw bignum_error("EncodeBase58 : BN_div failed");
-        bn = dv;
+        rem = bn % bn58;
+        bn /= bn58;
         unsigned int c = rem.getulong();
         str += pszBase58[c];
     }
@@ -75,7 +72,6 @@ inline std::string EncodeBase58(const std::vector<unsigned char>& vch)
 // returns true if decoding is successful
 inline bool DecodeBase58(const char* psz, std::vector<unsigned char>& vchRet)
 {
-    CAutoBN_CTX pctx;
     vchRet.clear();
     CBigNum bn58 = 58;
     CBigNum bn = 0;
@@ -96,8 +92,7 @@ inline bool DecodeBase58(const char* psz, std::vector<unsigned char>& vchRet)
             break;
         }
         bnChar.setulong(p1 - pszBase58);
-        if (!BN_mul(bn.bn, bn.bn, bn58.bn, pctx))
-            throw bignum_error("DecodeBase58 : BN_mul failed");
+        bn *= bn58;
         bn += bnChar;
     }
 


### PR DESCRIPTION
## Summary
- refactor base58 implementation to use the `CBigNum` operators
- drop direct BN functions

## Testing
- `make -f makefile.unix` *(fails: boost headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bd6f4eb4833292e35ba5ac16077d