### PR TITLE
Fix function name for random k-bit bignum generation

### DIFF
--- a/src/bignum.h
+++ b/src/bignum.h
@@ -146,7 +146,7 @@ public:
     * @param k The bit length of the number.
     * @return
     */
-    static CBigNum RandKBitBigum(const uint32_t k){
+    static CBigNum RandKBitBignum(const uint32_t k){
         CBigNum ret;
         if(!BN_rand(&ret, k, -1, 0)){
             throw bignum_error("CBigNum:rand element : BN_rand failed");


### PR DESCRIPTION
## Summary
- rename `RandKBitBigum` to `RandKBitBignum`

## Testing
- `make -f makefile.unix` *(fails: boost headers missing)*
- `make -f makefile.unix test_bitcoin` *(fails: no rule)*

------
https://chatgpt.com/codex/tasks/task_e_6854d15aedb0833299fefead6a35ee74