### PR TITLE
Add sha256 object to builds

### DIFF
--- a/Mic3.pro
+++ b/Mic3.pro
@@ -171,6 +171,7 @@ HEADERS += src/qt/bitcoingui.h \
     src/kernel.h \
     src/scrypt.h \
     src/pbkdf2.h \
+    src/crypto/sha256.h \
     src/zerocoin/Accumulator.h \
     src/zerocoin/AccumulatorProofOfKnowledge.h \
     src/zerocoin/Coin.h \
@@ -305,6 +306,7 @@ SOURCES += src/qt/bitcoin.cpp src/qt/bitcoingui.cpp \
     src/scrypt-x86_64.S \
     src/scrypt.cpp \
     src/pbkdf2.cpp \
+    src/crypto/sha256.cpp \
     src/zerocoin/Accumulator.cpp \
     src/zerocoin/AccumulatorProofOfKnowledge.cpp \
     src/zerocoin/Coin.cpp \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -62,6 +62,7 @@ OBJS= \
     obj/noui.o \
     obj/kernel.o \
     obj/pbkdf2.o \
+    obj/crypto/sha256.o \
     obj/scrypt.o \
     obj/scrypt-x86.o \
     obj/scrypt-x86_64.o \
@@ -91,10 +92,13 @@ obj/scrypt-x86.o: scrypt-x86.S
 	$(CXX) -c $(xCXXFLAGS) -MMD -o $@ $<
 obj/scrypt-x86_64.o: scrypt-x86_64.S
 	$(CXX) -c $(xCXXFLAGS) -MMD -o $@ $<
-Mousecoind.exe: $(OBJS:obj/%=obj/%)
+Mousecoind.exe: obj obj/zerocoin obj/crypto $(OBJS:obj/%=obj/%)
 	g++ $(CFLAGS) $(LDFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
+obj obj/zerocoin obj/crypto:
+	mkdir -p $@
 clean:
 	-del /Q Mousecoind
 	-del /Q obj\*
 	-del /Q obj\zerocoin\*
+	-del /Q obj\crypto\*
 FORCE:

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -86,6 +86,7 @@ OBJS= \
     obj/walletdb.o \
     obj/noui.o \
     obj/pbkdf2.o \
+    obj/crypto/sha256.o \
     obj/kernel.o \
     obj/scrypt.o \
     obj/scrypt-x86.o \
@@ -126,6 +127,11 @@ obj/txdb-leveldb.o: leveldb/libleveldb.a
 # auto-generated dependencies:
 -include obj/*.P
 
+Mousecoind:: obj obj/zerocoin obj/crypto
+
+obj obj/zerocoin obj/crypto:
+	mkdir -p $@
+
 obj/build.h: FORCE
 	/bin/sh ../share/genbuild.sh obj/build.h
 version.cpp: obj/build.h
@@ -151,15 +157,17 @@ obj/scrypt-x86.o: scrypt-x86.S
 obj/scrypt-x86_64.o: scrypt-x86_64.S
 	$(CXX) -c $(xCXXFLAGS) -MMD -o $@ $<
 
-Mousecoind: $(OBJS:obj/%=obj/%)
+Mousecoind:: $(OBJS:obj/%=obj/%)
 	$(CXX) $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
 
 clean:
 	-rm -f Mousecoind
 	-rm -f obj/*.o
 	-rm -f obj/zerocoin/*.o
+	-rm -f obj/crypto/*.o
 	-rm -f obj/*.P
 	-rm -f obj/zerocoin/*.P
+	-rm -f obj/crypto/*.P
 	-rm -f obj/build.h
 
 FORCE:

--- a/src/makefile.rpi
+++ b/src/makefile.rpi
@@ -142,6 +142,7 @@ OBJS= \
     obj/noui.o \
     obj/kernel.o \
     obj/pbkdf2.o \
+    obj/crypto/sha256.o \
     obj/scrypt.o \
     obj/scrypt-arm.o \
     obj/scrypt-x86.o \
@@ -170,9 +171,9 @@ obj/txdb-leveldb.o: leveldb/libleveldb.a
 # auto-generated dependencies:
 -include obj/*.P
 
-Mousecoind:: obj obj/zerocoin
+Mousecoind:: obj obj/zerocoin obj/crypto
 
-obj obj/zerocoin:
+obj obj/zerocoin obj/crypto:
 	mkdir -p $@
 
 obj/build.h: FORCE
@@ -210,8 +211,10 @@ clean:
 	-rm -f Mousecoind
 	-rm -f obj/*.o
 	-rm -f obj/zerocoin/*.o
+	-rm -f obj/crypto/*.o
 	-rm -f obj/*.P
 	-rm -f obj/zerocoin/*.P
+	-rm -f obj/crypto/*.P
 	-rm -f obj/build.h
 
 FORCE:

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -132,6 +132,7 @@ OBJS= \
     obj/noui.o \
     obj/kernel.o \
     obj/pbkdf2.o \
+    obj/crypto/sha256.o \
     obj/scrypt.o \
     obj/scrypt-arm.o \
     obj/scrypt-x86.o \
@@ -160,9 +161,9 @@ obj/txdb-leveldb.o: $(BASEDIR)/leveldb/libleveldb.a
 # auto-generated dependencies:
 -include obj/*.P
 
-Mousecoind:: obj obj/zerocoin
+Mousecoind:: obj obj/zerocoin obj/crypto
 
-obj obj/zerocoin:
+obj obj/zerocoin obj/crypto:
 	mkdir -p $@
 
 obj/build.h: FORCE
@@ -200,8 +201,10 @@ clean:
 	-rm -f Mousecoind
 	-rm -f obj/*.o
 	-rm -f obj/zerocoin/*.o
+	-rm -f obj/crypto/*.o
 	-rm -f obj/*.P
 	-rm -f obj/zerocoin/*.P
+	-rm -f obj/crypto/*.P
 	-rm -f obj/build.h
 
 FORCE:


### PR DESCRIPTION
## Summary
- link new crypto/sha256 implementation across build systems
- compile sha256.cpp in Qt project

## Testing
- `make -C src -f makefile.unix obj/crypto/sha256.o --dry-run`
- `make -C src -f makefile.osx obj/crypto/sha256.o --dry-run`
- `make -C src -f makefile.rpi obj/crypto/sha256.o --dry-run`
- `make -C src -f makefile.mingw obj/crypto/sha256.o --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_6854ed4aa9fc8332b16f80bc8873bfc2